### PR TITLE
Fix MySQL init script crashing container on every fresh deploy

### DIFF
--- a/docker/mysql/initdb.d/000-create-databases.sql
+++ b/docker/mysql/initdb.d/000-create-databases.sql
@@ -1,7 +1,19 @@
--- Use environment variables to avoid hardcoding database credentials
-CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE}
-    CHARACTER SET utf8mb4
-    COLLATE utf8mb4_unicode_ci;
-CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
-GRANT ALL PRIVILEGES ON ${MYSQL_DATABASE}.* TO '${MYSQL_USER}'@'%';
-FLUSH PRIVILEGES;
+-- NOTE: docker-entrypoint-initdb.d only shell-expands *.sh scripts; *.sql
+-- files are piped into the mysql client as-is, so ${MYSQL_DATABASE} etc.
+-- below are NOT substituted and previously caused a SQL syntax error on
+-- every fresh data volume (container exits 1, then restart: unless-stopped
+-- retries and succeeds because the data dir is no longer empty and initdb.d
+-- is skipped on retry - masking the failure instead of fixing it).
+--
+-- The database, user, and grants are already created by the official
+-- mariadb image itself from the MYSQL_DATABASE/MYSQL_USER/MYSQL_PASSWORD
+-- env vars (see docker-entrypoint.sh's "Creating database"/"Creating user"
+-- log lines), so this file is intentionally a no-op. Add real one-off SQL
+-- here only if it doesn't rely on env var substitution.
+--
+-- CREATE DATABASE IF NOT EXISTS devify
+--     CHARACTER SET utf8mb4
+--     COLLATE utf8mb4_unicode_ci;
+-- CREATE USER 'devify'@'%' IDENTIFIED BY 'password';
+-- GRANT ALL PRIVILEGES ON devify.* TO 'devify'@'%';
+-- FLUSH PRIVILEGES;


### PR DESCRIPTION
## Summary
- `docker/mysql/initdb.d/000-create-databases.sql` used `${MYSQL_DATABASE}`/`${MYSQL_USER}`/`${MYSQL_PASSWORD}` placeholders, but `docker-entrypoint-initdb.d` only shell-expands `*.sh` scripts — `*.sql` files are piped into the `mysql` client as-is, so these were never substituted.
- On every fresh MySQL data volume (first boot of `docker-compose.yml` or `docker-compose.dev.yml`), this caused a SQL syntax error and the `mysql`/`mariadb` container exited(1). `restart: unless-stopped` silently retried and succeeded the second time (initdb.d is skipped once the data dir is no longer empty), masking the crash behind extra restart delay and ERROR-level log noise.
- The database/user/grants are already created by the official mariadb image itself from the `MYSQL_DATABASE`/`MYSQL_USER`/`MYSQL_PASSWORD` env vars, so the file is now a no-op with the broken statements commented out for reference (matches the existing style of the sibling `001-create-tables.sql`).

## Test plan
- [x] Reproduced the crash standalone: `docker run` with the original file mounted as `docker-entrypoint-initdb.d`, confirmed via `docker logs -f` + `docker inspect` that the container exits with `ExitCode=1` due to the SQL syntax error.
- [x] Applied the fix and reran the same reproduction: container stays `running`/`ExitCode=0`, and `devify`/`devify` database+user work correctly (verified with `SHOW DATABASES` / `SELECT CURRENT_USER()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)