### PR TITLE
Show downloadable files with inline preview on conversation detail page

### DIFF
--- a/devify/threadline/serializers/email_attachment.py
+++ b/devify/threadline/serializers/email_attachment.py
@@ -13,10 +13,44 @@ from rest_framework import serializers
 from ..models import EmailAttachment
 
 
+def build_attachment_url(attachment):
+    """
+    Build the public download/preview URL for an attachment.
+
+    Extracts the relative path from ``file_path`` (supports both legacy
+    ``email_<id>/file`` and uuid-based ``<uuid>/file`` layouts) and prefixes
+    it with ``ATTACHMENT_BASE_URL`` when configured. Files are served by nginx
+    at ``/attachments/<rel_path>``.
+
+    Args:
+        attachment: EmailAttachment instance
+
+    Returns:
+        str: Public URL, or empty string when no file_path is set
+    """
+    if not attachment.file_path:
+        return ""
+
+    # Anchor the strip to the storage-dir prefix so a file_path that is not
+    # under EMAIL_ATTACHMENT_DIR (legacy/misconfigured import) does not leak
+    # an absolute filesystem path into the URL via an unanchored replace.
+    prefix = settings.EMAIL_ATTACHMENT_DIR.rstrip("/") + "/"
+    if attachment.file_path.startswith(prefix):
+        rel_path = attachment.file_path[len(prefix):]
+    else:
+        rel_path = attachment.file_path.lstrip("/")
+
+    if settings.ATTACHMENT_BASE_URL:
+        return f"{settings.ATTACHMENT_BASE_URL}/attachments/{rel_path}"
+    return f"/attachments/{rel_path}"
+
+
 class EmailAttachmentNestedSerializer(serializers.ModelSerializer):
     """
     Nested serializer for EmailAttachment - used within EmailMessage
     """
+
+    url = serializers.SerializerMethodField()
 
     class Meta:
         model = EmailAttachment
@@ -26,6 +60,7 @@ class EmailAttachmentNestedSerializer(serializers.ModelSerializer):
             "content_type",
             "file_size",
             "file_path",
+            "url",
             "content_md5",
             "ocr_content",
             "llm_content",
@@ -35,6 +70,24 @@ class EmailAttachmentNestedSerializer(serializers.ModelSerializer):
             "updated_at",
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
+
+    def get_url(self, obj) -> str:
+        """Return the public download/preview URL for this attachment."""
+        return build_attachment_url(obj)
+
+    def to_representation(self, instance):
+        """
+        Drop download pointers in the public share context.
+
+        Public (unauthenticated) share links must not hand out downloadable
+        URLs for original attachments, so remove ``url`` and ``file_path``
+        when the serializer is invoked with ``public_share`` in its context.
+        """
+        data = super().to_representation(instance)
+        if self.context.get("public_share"):
+            data.pop("url", None)
+            data.pop("file_path", None)
+        return data
 
 
 class EmailAttachmentMinimalSerializer(serializers.ModelSerializer):

--- a/devify/threadline/serializers/email_message.py
+++ b/devify/threadline/serializers/email_message.py
@@ -6,7 +6,6 @@ Serializers for EmailMessage model CRUD operations.
 
 import re
 
-from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
@@ -16,6 +15,7 @@ from .base import UserSerializer
 from .email_attachment import (
     EmailAttachmentMinimalSerializer,
     EmailAttachmentNestedSerializer,
+    build_attachment_url,
 )
 from .email_todo import EmailTodoListSerializer
 from .share_link import ThreadlineShareLinkSerializer
@@ -491,21 +491,9 @@ class EmailMessageSerializer(serializers.ModelSerializer):
         attachment_url_map = {}
         for att in instance.attachments.all():
             if att.is_image and att.file_path:
-                rel_path = att.file_path.replace(
-                    settings.EMAIL_ATTACHMENT_DIR + "/",
-                    "",
-                ).lstrip("/")
-
-                # Generate URL
-                if settings.ATTACHMENT_BASE_URL:
-                    url = (
-                        f"{settings.ATTACHMENT_BASE_URL}/attachments/"
-                        f"{rel_path}"
-                    )
-                else:
-                    url = f"/attachments/{rel_path}"
-
-                attachment_url_map[att.safe_filename] = url
+                attachment_url_map[att.safe_filename] = build_attachment_url(
+                    att
+                )
 
         # Replace placeholders in all content fields
         for field in ["llm_content", "summary_content"]:

--- a/devify/threadline/views/share_link.py
+++ b/devify/threadline/views/share_link.py
@@ -159,9 +159,12 @@ class PublicShareLinkAPIView(APIView):
         """
         Return serialized email message data for public consumption.
         """
+        # public_share=True strips download pointers (url/file_path) from
+        # attachments so unauthenticated share links do not expose original
+        # files for direct download.
         message_serializer = EmailMessageSerializer(
             share_link.email_message,
-            context={'request': request}
+            context={'request': request, 'public_share': True}
         )
         share_link.mark_viewed()
         return Response({

--- a/ui/src/admin/pages/DataManagement/components/ConversationDetail.vue
+++ b/ui/src/admin/pages/DataManagement/components/ConversationDetail.vue
@@ -908,7 +908,7 @@
 
 <script setup>
 import { useI18n } from 'vue-i18n'
-import { formatDuration } from '@/utils/formatting'
+import { formatBytes, formatDuration } from '@/utils/formatting'
 import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseLoading from '@/components/ui/BaseLoading.vue'
 import MarkdownRenderer from '@/components/ui/MarkdownRenderer.vue'
@@ -1030,16 +1030,6 @@ function formatDateTime(value) {
   } catch {
     return String(value)
   }
-}
-
-function formatBytes(value) {
-  const size = Number(value)
-  if (!Number.isFinite(size) || size < 0) return '-'
-  if (size < 1024) return `${size} B`
-  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
-  if (size < 1024 * 1024 * 1024)
-    return `${(size / (1024 * 1024)).toFixed(1)} MB`
-  return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
 function formatStepTime(value) {

--- a/ui/src/components/threadline/ThreadlineAttachments.vue
+++ b/ui/src/components/threadline/ThreadlineAttachments.vue
@@ -1,0 +1,362 @@
+<template>
+  <BaseCard v-if="attachments.length" :header-muted="true">
+    <template #header>
+      <div class="flex items-center gap-2 text-gray-800">
+        <svg
+          class="w-5 h-5 -mt-px flex-none"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+          />
+        </svg>
+        <h3 class="text-base font-semibold leading-5">
+          {{ t('chats.files.title') }}
+          <span class="text-gray-400 font-normal"
+            >({{ attachments.length }})</span
+          >
+        </h3>
+      </div>
+    </template>
+
+    <div
+      class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-3"
+    >
+      <div
+        v-for="att in attachments"
+        :key="att.id"
+        class="group relative rounded-lg border border-gray-200 bg-white overflow-hidden hover:shadow-sm transition-shadow"
+      >
+        <!-- Preview / icon area (square) -->
+        <button
+          type="button"
+          class="block w-full aspect-square bg-gray-50 overflow-hidden"
+          :title="att.filename"
+          @click="onTileClick(att)"
+        >
+          <img
+            v-if="isImage(att) && att.url"
+            :src="att.url"
+            :alt="att.filename"
+            loading="lazy"
+            class="w-full h-full object-cover transition-transform group-hover:scale-105"
+          />
+          <span
+            v-else
+            class="w-full h-full flex flex-col items-center justify-center gap-2"
+          >
+            <span
+              class="flex h-11 w-11 items-center justify-center rounded-lg"
+              :class="chipClass(att)"
+            >
+              <span class="text-xs font-bold tracking-wide uppercase">
+                {{ extLabel(att) }}
+              </span>
+            </span>
+          </span>
+        </button>
+
+        <!-- Footer: filename + download -->
+        <div
+          class="flex items-center gap-1 px-2 py-1.5 border-t border-gray-100"
+        >
+          <span
+            class="flex-1 min-w-0 truncate text-xs text-gray-700"
+            :title="att.filename"
+          >
+            {{ att.filename }}
+          </span>
+          <a
+            v-if="att.url"
+            :href="att.url"
+            :download="att.filename"
+            class="flex-none text-gray-400 hover:text-blue-600"
+            :title="t('chats.files.download')"
+            @click.stop
+          >
+            <svg
+              class="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+              />
+            </svg>
+          </a>
+        </div>
+
+        <!-- Size badge -->
+        <span
+          v-if="att.file_size != null"
+          class="absolute top-1 left-1 rounded bg-black/50 px-1 py-0.5 text-[10px] leading-none text-white"
+        >
+          {{ formatBytes(att.file_size) }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Preview modal (image or text) -->
+    <Teleport to="body">
+      <div
+        v-if="preview"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+        @click="closePreview"
+      >
+        <img
+          v-if="preview.type === 'image'"
+          :src="preview.att.url"
+          :alt="preview.att.filename"
+          class="max-h-[90vh] max-w-[90vw] object-contain rounded shadow-xl"
+          @click.stop
+        />
+
+        <div
+          v-else
+          class="flex w-full flex-col overflow-hidden rounded-lg bg-white shadow-xl"
+          :class="
+            preview.type === 'pdf'
+              ? 'max-w-5xl h-[90vh]'
+              : 'max-w-3xl max-h-[85vh]'
+          "
+          @click.stop
+        >
+          <div
+            class="flex items-center gap-2 border-b border-gray-200 px-4 py-2.5"
+          >
+            <span
+              class="flex-1 min-w-0 truncate text-sm font-medium text-gray-800"
+            >
+              {{ preview.att.filename }}
+            </span>
+            <a
+              :href="preview.att.url"
+              :download="preview.att.filename"
+              class="flex-none text-xs font-medium text-blue-600 hover:text-blue-800"
+            >
+              {{ t('chats.files.download') }}
+            </a>
+            <button
+              type="button"
+              class="flex-none text-gray-400 hover:text-gray-700"
+              :aria-label="t('common.close')"
+              @click="closePreview"
+            >
+              <svg
+                class="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+          <iframe
+            v-if="preview.type === 'pdf'"
+            :src="preview.att.url"
+            :title="preview.att.filename"
+            class="flex-1 w-full border-0"
+          />
+          <div v-else class="flex-1 overflow-auto p-4">
+            <div v-if="preview.loading" class="text-sm text-gray-500 italic">
+              {{ t('common.loading') }}
+            </div>
+            <div v-else-if="preview.error" class="text-sm text-red-500">
+              {{ preview.error }}
+            </div>
+            <pre
+              v-else
+              class="whitespace-pre-wrap break-words text-xs text-gray-700"
+              >{{ preview.content }}</pre
+            >
+          </div>
+        </div>
+
+        <button
+          v-if="preview.type === 'image'"
+          type="button"
+          class="absolute top-4 right-4 text-white/80 hover:text-white"
+          :aria-label="t('common.close')"
+          @click="closePreview"
+        >
+          <svg
+            class="w-8 h-8"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </Teleport>
+  </BaseCard>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseCard from '@/components/ui/BaseCard.vue'
+import { formatBytes } from '@/utils/formatting'
+
+const { t } = useI18n()
+
+defineProps({
+  attachments: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const TEXT_CONTENT_TYPES = [
+  'application/json',
+  'application/xml',
+  'application/x-yaml',
+  'application/yaml',
+  'application/x-sh'
+]
+
+// Extension -> colored chip. Lets Word/Excel/PDF/etc. read as intentional
+// file types instead of a generic gray icon.
+const TYPE_COLORS = {
+  pdf: 'bg-red-50 text-red-600',
+  doc: 'bg-blue-50 text-blue-600',
+  docx: 'bg-blue-50 text-blue-600',
+  xls: 'bg-green-50 text-green-600',
+  xlsx: 'bg-green-50 text-green-600',
+  csv: 'bg-green-50 text-green-600',
+  ppt: 'bg-orange-50 text-orange-600',
+  pptx: 'bg-orange-50 text-orange-600',
+  zip: 'bg-amber-50 text-amber-600',
+  rar: 'bg-amber-50 text-amber-600',
+  '7z': 'bg-amber-50 text-amber-600'
+}
+
+const MAX_TEXT_PREVIEW = 100000
+
+function isImage(att) {
+  return (
+    att.is_image || (att.content_type || '').toLowerCase().startsWith('image/')
+  )
+}
+
+function isText(att) {
+  const ct = (att.content_type || '').toLowerCase()
+  return ct.startsWith('text/') || TEXT_CONTENT_TYPES.includes(ct)
+}
+
+function isPdf(att) {
+  return (
+    (att.content_type || '').toLowerCase() === 'application/pdf' ||
+    ext(att) === 'pdf'
+  )
+}
+
+// Full file extension (lowercased), used for type logic (isPdf, chipClass).
+function ext(att) {
+  const name = att.filename || ''
+  const dot = name.lastIndexOf('.')
+  if (dot >= 0 && dot < name.length - 1) {
+    return name.slice(dot + 1).toLowerCase()
+  }
+  return ''
+}
+
+// Short label for the type chip; falls back to a generic "file" word.
+function extLabel(att) {
+  const e = ext(att)
+  return e ? e.slice(0, 4) : t('chats.files.file')
+}
+
+function chipClass(att) {
+  return TYPE_COLORS[ext(att)] || 'bg-gray-100 text-gray-500'
+}
+
+// Unified preview modal state (image or text), null when closed
+const preview = ref(null)
+
+function onTileClick(att) {
+  if (!att.url) return
+  if (isImage(att)) {
+    preview.value = { type: 'image', att }
+  } else if (isPdf(att)) {
+    preview.value = { type: 'pdf', att }
+  } else if (isText(att)) {
+    openTextPreview(att)
+  } else {
+    // Non-previewable (Word/Excel/PPT/archives): download instead
+    triggerDownload(att)
+  }
+}
+
+async function openTextPreview(att) {
+  preview.value = {
+    type: 'text',
+    att,
+    loading: true,
+    error: '',
+    content: ''
+  }
+  const state = preview.value
+  try {
+    // Request only the head of the file via a Range request so a huge
+    // attachment is not fully buffered into memory just to show a preview.
+    // nginx serves byte ranges on static files; if it ignores the header we
+    // still cap the text below. Note: att.url is same-origin (relative) here;
+    // a cross-origin ATTACHMENT_BASE_URL would need CORS for this fetch.
+    const res = await fetch(att.url, {
+      headers: { Range: `bytes=0-${MAX_TEXT_PREVIEW - 1}` }
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    let text = await res.text()
+    if (text.length > MAX_TEXT_PREVIEW) {
+      text = text.slice(0, MAX_TEXT_PREVIEW) + '\n…'
+    }
+    // Ignore if the modal was closed/switched while fetching
+    if (preview.value !== state) return
+    state.content = text
+  } catch (e) {
+    if (preview.value !== state) return
+    state.error = t('chats.files.previewError')
+  } finally {
+    if (preview.value === state) state.loading = false
+  }
+}
+
+// Relies on the anchor `download` attribute, which browsers honor only for
+// same-origin URLs. att.url is relative/same-origin in this deployment; a
+// cross-origin ATTACHMENT_BASE_URL would open the file in-tab instead of
+// saving it and would need a blob-based download.
+function triggerDownload(att) {
+  const a = document.createElement('a')
+  a.href = att.url
+  a.download = att.filename || ''
+  document.body.appendChild(a)
+  a.click()
+  a.remove()
+}
+
+function closePreview() {
+  preview.value = null
+}
+</script>

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -417,6 +417,12 @@
       "label": "Delivery",
       "openInNewWindow": "Open in new window"
     },
+    "files": {
+      "title": "Files",
+      "download": "Download",
+      "previewError": "Failed to load preview",
+      "file": "File"
+    },
     "errorLoading": "Error loading threadline",
     "errorLoadingDesc": "Failed to load conversation details"
   },

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -216,6 +216,12 @@
       "openInNewWindow": "Abrir en una nueva ventana",
       "reference": "Problema"
     },
+    "files": {
+      "title": "Archivos",
+      "download": "Descargar",
+      "previewError": "No se pudo cargar la vista previa",
+      "file": "Archivo"
+    },
     "errorLoading": "Error al cargar el hilo de conversación",
     "errorLoadingDesc": "No se pudieron cargar los detalles de la conversación"
   },

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -427,6 +427,12 @@
       "label": "投递",
       "openInNewWindow": "在新窗口打开"
     },
+    "files": {
+      "title": "文件",
+      "download": "下载",
+      "previewError": "预览加载失败",
+      "file": "文件"
+    },
     "errorLoading": "加载对话详情失败",
     "errorLoadingDesc": "无法加载对话详情"
   },

--- a/ui/src/pages/ThreadlineDetail.vue
+++ b/ui/src/pages/ThreadlineDetail.vue
@@ -2033,6 +2033,9 @@
           <p class="text-sm mt-2">{{ t('chats.processedContentDesc') }}</p>
         </div>
       </BaseCard>
+
+      <!-- Attachments / Files -->
+      <ThreadlineAttachments :attachments="threadline.attachments || []" />
     </div>
     <MetadataFieldEditor
       :show="showEditor"
@@ -2347,6 +2350,7 @@ import BaseButton from '@/components/ui/BaseButton.vue'
 import BaseModal from '@/components/ui/BaseModal.vue'
 import MergeStateBadge from '@/components/ui/MergeStateBadge.vue'
 import MarkdownRenderer from '@/components/ui/MarkdownRenderer.vue'
+import ThreadlineAttachments from '@/components/threadline/ThreadlineAttachments.vue'
 import { useThreadline } from '@/composables/useThreadline'
 import { useThreadlinePolling } from '@/composables/useThreadlinePolling'
 import { useThreadlineShare } from '@/composables/useThreadlineShare'

--- a/ui/src/utils/formatting.js
+++ b/ui/src/utils/formatting.js
@@ -40,6 +40,16 @@ export function formatDateIsoLocale(value, locale) {
   return date.toLocaleString(getLocale(locale))
 }
 
+export function formatBytes(value) {
+  const size = Number(value)
+  if (!Number.isFinite(size) || size < 0) return '-'
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  if (size < 1024 * 1024 * 1024)
+    return `${(size / (1024 * 1024)).toFixed(1)} MB`
+  return `${(size / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
 export function formatDuration(seconds) {
   const sec = toNumber(seconds)
   if (sec == null) return '-'


### PR DESCRIPTION
## Summary

Adds a **Files** section to the conversation (threadline) detail page that lists all attachments as a responsive grid of tiles, with download and inline preview. Closes #10.

Presentation by type:
- **Images** — thumbnail tile → click-to-enlarge lightbox
- **PDF** — inline `<iframe>` preview in a modal (browsers render PDF natively)
- **Text / JSON / XML / YAML** — inline preview, fetched with a `Range` request so large files are not fully buffered into browser memory
- **Word / Excel / PPT / archives** — colored type chip (Word=blue, Excel=green, PDF=red, …), download-only (Office formats can't render natively and the Microsoft/Google viewers need a public URL)

## Backend

- New `build_attachment_url()` helper + computed `url` field on `EmailAttachmentNestedSerializer`. The helper is reused in `EmailMessageSerializer.to_representation`, so **inline body images and attachment URLs now share one code path** (removed the previously duplicated inline logic).
- The prefix strip is **anchored** to `EMAIL_ATTACHMENT_DIR` so a `file_path` stored outside that dir can't leak an absolute filesystem path into the URL.
- **Security:** the public (unauthenticated) share endpoint reuses `EmailMessageSerializer`, so `url`/`file_path` are **stripped in the `public_share` context** — share links no longer expose original attachments (Word/Excel/PDF/…) for direct download. Filename/type/size metadata is still returned.

## Frontend

- New thin `ThreadlineAttachments.vue` component, mounted from the detail page (parent stays an orchestration layer).
- `formatBytes` extracted to `ui/src/utils/formatting.js` and reused by the admin `ConversationDetail` component (deduplicates the byte-size formatter).
- i18n under `chats.files` for `en` / `zh-CN` / `es`.

## Notes / limitations

- Attachment URLs are **relative (same-origin)**; they are served by the same nginx that serves the UI. Download (anchor `download` attribute) and the text-preview `fetch` assume same-origin — a cross-origin `ATTACHMENT_BASE_URL` (e.g. a CDN) would need a blob download + CORS. This is documented in code comments.

## Validation

- Backend: verified at runtime that the `url` field resolves for real attachments, the `public_share` context strips `url`/`file_path` while keeping metadata, the anchored prefix strip handles paths in/outside the storage dir, and body-image vs attachment URLs are byte-identical for the same file. `flake8` clean on changed lines.
- Frontend: `npm run build` passes; ESLint clean on new/changed files; all three locale JSON files validate.
- This branch was reviewed with a multi-agent code review (9 findings); all were addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RKBwEuSDcdc4dHZoZRrCt
