### PR TITLE
Avoid false email merges on sparse text and mismatched images

### DIFF
--- a/devify/threadline/services/email_merge.py
+++ b/devify/threadline/services/email_merge.py
@@ -56,6 +56,10 @@ class EmailMergeService:
     RAPIDFUZZ_PARTIAL_RATIO_THRESHOLD = 80.0
     MIN_TEXT_EXTENSION = 40
     MIN_TEXT_EXTENSION_RATIO = 0.30
+    # Below this normalized-text length, fuzzy similarity is unreliable
+    # (image-heavy emails with a one-line note over-trigger the thresholds),
+    # so require exact equality instead of trusting RapidFuzz.
+    MIN_TEXT_SIMILARITY_LENGTH = 120
 
     def decide(self, email: EmailMessage) -> MergeDecision:
         """
@@ -282,6 +286,20 @@ class EmailMergeService:
                 f" email_id={email.id} candidate_id={candidate.id}"
             )
             return True
+        # The matchers only compare text; for image-heavy emails the real
+        # content lives in the images. When both records carry images and the
+        # image sets are completely different, the content-based signals below
+        # are not trustworthy, so block the merge. This is intentional: a
+        # recurring series with the same boilerplate text but a fresh image
+        # each time is kept as separate conversations rather than fused.
+        # Thread-header matches above stay authoritative (a genuine reply with
+        # a new screenshot still merges via In-Reply-To/References).
+        if self._has_disjoint_images(email, candidate):
+            logger.debug(
+                f"[EmailMerge] blocked by disjoint images"
+                f" email_id={email.id} candidate_id={candidate.id}"
+            )
+            return False
         if self._matches_forward_chain(email, candidate):
             logger.debug(
                 f"[EmailMerge] matcher hit forward_chain"
@@ -400,7 +418,13 @@ class EmailMergeService:
         if candidate_subject != normalized_subject:
             return False
 
-        return self._matches_text_similarity(email, candidate)
+        # A forward is already a strong signal (Fwd prefix + identical
+        # subject), so do not apply the short-text length floor here; the
+        # floor exists only to keep the weaker text_similarity path from
+        # over-matching on tiny bodies.
+        return self._text_bodies_match(
+            email, candidate, apply_length_floor=False
+        )
 
     def _matches_text_similarity(
         self, email: EmailMessage, candidate: EmailMessage
@@ -417,13 +441,37 @@ class EmailMergeService:
         if self._normalize_subject(candidate.subject) != normalized_subject:
             return False
 
-        # Keep the merge heuristic simple and predictable: only compare raw
-        # extracted text. If a record has no text_content, skip it instead of
-        # trying to infer from HTML.
+        return self._text_bodies_match(
+            email, candidate, apply_length_floor=True
+        )
+
+    def _text_bodies_match(
+        self,
+        email: EmailMessage,
+        candidate: EmailMessage,
+        apply_length_floor: bool,
+    ) -> bool:
+        """
+        Compare the two records' extracted text bodies.
+
+        Keep the heuristic simple and predictable: only compare raw extracted
+        text; if a record has no text_content, skip it instead of inferring
+        from HTML. When ``apply_length_floor`` is set, short bodies (e.g. an
+        image plus a one-line note or a shared signature/footer) make RapidFuzz
+        unreliable, so require exact normalized-text equality below the length
+        floor instead of a fuzzy score.
+        """
         current_text = self._normalize_text(email.text_content)
         candidate_text = self._normalize_text(candidate.text_content)
         if not current_text or not candidate_text:
             return False
+
+        if (
+            apply_length_floor
+            and min(len(current_text), len(candidate_text))
+            < self.MIN_TEXT_SIMILARITY_LENGTH
+        ):
+            return current_text == candidate_text
 
         ratio, partial_ratio = self._text_similarity_scores(
             candidate_text, current_text
@@ -448,6 +496,44 @@ class EmailMergeService:
         if not current_text or not candidate_text:
             return False
         return self._is_strong_containment(candidate_text, current_text)
+
+    def _image_md5_set(self, email: EmailMessage) -> set:
+        """
+        Content MD5s of this record's image attachments (empty if none).
+
+        Queried lazily and cached on the model instance so the arriving email
+        is fetched at most once and each candidate at most once. Only reached
+        when the arriving email itself has images (see _has_disjoint_images),
+        so mailboxes without image attachments never hit this query.
+        """
+        cached = getattr(email, "_merge_image_md5s", None)
+        if cached is not None:
+            return cached
+        result = {
+            att.content_md5
+            for att in email.attachments.all()
+            if att.is_image and att.content_md5
+        }
+        email._merge_image_md5s = result
+        return result
+
+    def _has_disjoint_images(
+        self, email: EmailMessage, candidate: EmailMessage
+    ) -> bool:
+        """
+        True when both records have image attachments and their content MD5
+        sets do not overlap at all.
+
+        Returns False (do not block) when either side has no comparable image
+        MD5s, so records without images fall through to normal matching.
+        """
+        email_images = self._image_md5_set(email)
+        if not email_images:
+            return False
+        candidate_images = self._image_md5_set(candidate)
+        if not candidate_images:
+            return False
+        return email_images.isdisjoint(candidate_images)
 
     def _candidate_queryset(self, email: EmailMessage):
         """

--- a/devify/threadline/tests/unit/test_email_merge.py
+++ b/devify/threadline/tests/unit/test_email_merge.py
@@ -10,14 +10,35 @@ from django.contrib.auth.models import User
 from datetime import timedelta
 from unittest.mock import patch
 
-from threadline.models import EmailMessage
+from threadline.models import EmailAttachment, EmailMessage
 from threadline.services.email_merge import EmailMergeService
 
 
 class TestEmailMergeService(TestCase):
+    # >=120 chars so text_similarity uses fuzzy matching; short bodies now
+    # require exact equality (see MIN_TEXT_SIMILARITY_LENGTH).
+    LONG_TEXT = (
+        "Please review the deployment runbook and the rollback plan before "
+        "the Friday release window and confirm the on-call rotation is "
+        "staffed for the weekend shift."
+    )
+
     def setUp(self):
         self.service = EmailMergeService()
         self.user = self._create_user()
+
+    def _attach_image(self, email, content_md5):
+        return EmailAttachment.objects.create(
+            user=email.user,
+            email_message=email,
+            filename=f"{content_md5[:8]}.png",
+            safe_filename=f"{content_md5[:8]}.png",
+            content_type="image/png",
+            file_size=1024,
+            file_path=f"/tmp/{content_md5[:8]}.png",
+            content_md5=content_md5,
+            is_image=True,
+        )
 
     def _create_user(self, username: str | None = None) -> User:
         username = username or f"tester_{uuid4().hex[:8]}"
@@ -58,13 +79,24 @@ class TestEmailMergeService(TestCase):
         return EmailMessage.objects.create(**defaults)
 
     def test_similarity_does_not_merge_when_both_scores_are_low(self):
+        # Bodies are long enough (>= 120 chars) to bypass the exact-equality
+        # floor, so this exercises the RapidFuzz low-score rejection path:
+        # same subject but genuinely different content must not merge.
         parent = self._create_email(
             subject="Project review",
-            text_content="Alpha beta gamma delta epsilon zeta eta theta",
+            text_content=(
+                "The quarterly budget review meeting is scheduled for next "
+                "Tuesday afternoon in the main conference room; please bring "
+                "your department figures and the latest forecast."
+            ),
         )
         source = self._create_email(
             subject="Project review",
-            text_content="theta and appendix with unrelated notes",
+            text_content=(
+                "Reminder that the office will be closed on Friday for the "
+                "public holiday and all deliveries should be rescheduled to "
+                "the following business week without exception."
+            ),
             received_at=timezone.now(),
         )
 
@@ -107,12 +139,12 @@ class TestEmailMergeService(TestCase):
     def test_similarity_merges_when_partial_ratio_is_high(self):
         parent = self._create_email(
             subject="Project review",
-            text_content="Alpha beta gamma delta epsilon zeta eta theta",
+            text_content=self.LONG_TEXT,
         )
         source = self._create_email(
             subject="Project review",
             text_content=(
-                "beta gamma delta epsilon zeta eta theta plus an appendix"
+                self.LONG_TEXT + " with an appendix section appended."
             ),
             received_at=timezone.now(),
         )
@@ -134,6 +166,9 @@ class TestEmailMergeService(TestCase):
         )
 
     def test_forward_chain_with_added_content_merges(self):
+        # A short forward (original body < 120 chars) with an added note must
+        # still merge: forward_chain is a strong signal and is not subject to
+        # the text_similarity short-text length floor.
         parent = self._create_email(
             subject="Project notes",
             text_content="We should keep the old plan",
@@ -175,19 +210,12 @@ class TestEmailMergeService(TestCase):
     def test_prefers_earliest_record_within_window(self):
         older = self._create_email(
             subject="Status brief",
-            text_content=(
-                "Line 1\n"
-                "Line 2\n"
-                "Line 3\n"
-                "Line 4\n"
-                "Line 5\n"
-                "Line 6\n"
-            ),
+            text_content=self.LONG_TEXT + " An older extra line for length.",
             received_at=timezone.now() - timedelta(days=1),
         )
         newer = self._create_email(
             subject="Status brief",
-            text_content="Line 1\nLine 2\nLine 3",
+            text_content=self.LONG_TEXT,
             received_at=timezone.now(),
         )
 
@@ -263,19 +291,12 @@ class TestEmailMergeService(TestCase):
     def test_reconcile_keeps_newest_as_canonical_and_absorbs_older(self):
         older = self._create_email(
             subject="Status brief",
-            text_content=(
-                "Line 1\n"
-                "Line 2\n"
-                "Line 3\n"
-                "Line 4\n"
-                "Line 5\n"
-                "Line 6\n"
-            ),
+            text_content=self.LONG_TEXT + " An older extra line for length.",
             received_at=timezone.now() - timedelta(days=1),
         )
         newer = self._create_email(
             subject="Status brief",
-            text_content="Line 1\nLine 2\nLine 3",
+            text_content=self.LONG_TEXT,
             received_at=timezone.now(),
         )
 
@@ -294,19 +315,12 @@ class TestEmailMergeService(TestCase):
         manual_canonical = self._create_email(
             message_id="manual-merge-abc123",
             subject="Status brief",
-            text_content=(
-                "Line 1\n"
-                "Line 2\n"
-                "Line 3\n"
-                "Line 4\n"
-                "Line 5\n"
-                "Line 6\n"
-            ),
+            text_content=self.LONG_TEXT + " A manual canonical extra line.",
             received_at=timezone.now() - timedelta(days=1),
         )
         arriving = self._create_email(
             subject="Status brief",
-            text_content="Line 1\nLine 2\nLine 3",
+            text_content=self.LONG_TEXT,
             received_at=timezone.now(),
         )
 
@@ -323,26 +337,19 @@ class TestEmailMergeService(TestCase):
     def test_reconcile_absorbs_existing_cluster_head_for_new_arrival(self):
         first = self._create_email(
             subject="Status brief",
-            text_content=(
-                "Line 1\n"
-                "Line 2\n"
-                "Line 3\n"
-                "Line 4\n"
-                "Line 5\n"
-                "Line 6\n"
-            ),
+            text_content=self.LONG_TEXT + " First variant note.",
             received_at=timezone.now() - timedelta(days=2),
         )
         second = self._create_email(
             subject="Status brief",
-            text_content="Line 1\nLine 2\nLine 3\nLine 4",
+            text_content=self.LONG_TEXT + " Second variant note.",
             received_at=timezone.now() - timedelta(days=1),
         )
         self.service.reconcile(second)
 
         third = self._create_email(
             subject="Status brief",
-            text_content="Line 1\nLine 2\nLine 3",
+            text_content=self.LONG_TEXT,
             received_at=timezone.now(),
         )
         canonical, decision = self.service.reconcile(third)
@@ -500,3 +507,106 @@ class TestEmailMergeService(TestCase):
         assert evidence is not None
         assert evidence["reason"] == head_b.merge_reason
         assert evidence.get("signal")
+
+    def test_short_similar_text_below_floor_does_not_merge(self):
+        # Same subject, short bodies that are similar but not identical (the
+        # image-note / boilerplate false-merge case) must not merge.
+        parent = self._create_email(
+            subject="Ping",
+            text_content="Please see the attached screenshot.",
+            received_at=timezone.now() - timedelta(minutes=5),
+        )
+        source = self._create_email(
+            subject="Ping",
+            text_content="Please check the attached screenshot.",
+            received_at=timezone.now(),
+        )
+
+        decision = self.service.decide(source)
+
+        assert parent.pk is not None
+        assert decision.should_merge is False
+
+    def test_short_identical_text_still_merges(self):
+        # Exact short duplicates are still allowed to merge.
+        parent = self._create_email(
+            subject="Ping",
+            text_content="Please see the attached screenshot.",
+            received_at=timezone.now() - timedelta(minutes=5),
+        )
+        source = self._create_email(
+            subject="Ping",
+            text_content="Please see the attached screenshot.",
+            received_at=timezone.now(),
+        )
+
+        decision = self.service.decide(source)
+
+        assert decision.should_merge is True
+        assert decision.target == parent
+
+    def test_disjoint_images_block_content_merge(self):
+        # Long, near-identical text would merge on its own, but completely
+        # different images mean the content-based signal is untrustworthy.
+        parent = self._create_email(
+            subject="Report",
+            text_content=self.LONG_TEXT,
+            received_at=timezone.now() - timedelta(minutes=5),
+        )
+        self._attach_image(parent, "a" * 32)
+        source = self._create_email(
+            subject="Report",
+            text_content=self.LONG_TEXT,
+            received_at=timezone.now(),
+        )
+        self._attach_image(source, "b" * 32)
+
+        decision = self.service.decide(source)
+
+        assert decision.should_merge is False
+
+    def test_shared_image_allows_content_merge(self):
+        # Same text and an overlapping image still merges.
+        parent = self._create_email(
+            subject="Report",
+            text_content=self.LONG_TEXT,
+            received_at=timezone.now() - timedelta(minutes=5),
+        )
+        self._attach_image(parent, "c" * 32)
+        source = self._create_email(
+            subject="Report",
+            text_content=self.LONG_TEXT,
+            received_at=timezone.now(),
+        )
+        self._attach_image(source, "c" * 32)
+
+        decision = self.service.decide(source)
+
+        assert decision.should_merge is True
+        assert decision.target == parent
+
+    def test_thread_relation_merges_despite_disjoint_images(self):
+        # Header-based threading is authoritative and wins over the image
+        # guard even when the images are completely different.
+        parent = self._create_email(
+            subject="Report",
+            text_content="short note",
+            raw_message_id="root@example.com",
+            received_at=timezone.now() - timedelta(minutes=5),
+        )
+        self._attach_image(parent, "a" * 32)
+        source = self._create_email(
+            subject="Re: Report",
+            text_content="different short note",
+            in_reply_to="<root@example.com>",
+            received_at=timezone.now(),
+        )
+        self._attach_image(source, "b" * 32)
+
+        decision = self.service.decide(source)
+
+        assert decision.should_merge is True
+        assert (
+            decision.reason
+            == EmailMessage.MergeReason.THREAD_RELATION.value
+        )


### PR DESCRIPTION
## Summary

Stops the email/threadline merge from fusing unrelated emails that share only a little text, and makes it aware of images. Closes #13.

The merge only ever compared `text_content`, never images. So two image-heavy emails with a same subject and a tiny bit of shared boilerplate text (a greeting, signature, or one-line note) could be merged even though their images — the actual content — were completely different. This was the production case behind conversation `01e55fb0-…`.

## Changes (both scoped to content-based matchers; `thread_relation` header matching stays authoritative and unaffected)

- **Text length floor** (`MIN_TEXT_SIMILARITY_LENGTH = 120`): below the floor, `text_similarity` requires **exact** normalized-text equality instead of a fuzzy RapidFuzz score, so tiny bodies no longer over-match. Scoped to `text_similarity` only via a shared `_text_bodies_match(apply_length_floor=…)` helper — `forward_chain` (Fwd + identical subject) keeps fuzzy matching, so genuine **short forwards still merge**.
- **Disjoint-image guard**: when both records carry image attachments whose `content_md5` sets are completely **disjoint**, block the content-based merge. Image MD5s are queried **lazily** and cached per model instance, so mailboxes without images never incur an extra query.

## Deliberate trade-off

A recurring series with the same boilerplate text but a fresh image each time (and no threading headers) is now kept as **separate** conversations rather than fused. This is intentional and matches the reported expectation that emails with completely different images are different conversations. A genuine reply with a new screenshot still merges via `In-Reply-To`/`References`.

## Review

Went through a multi-agent review that caught a real regression in the first implementation: the length floor, reached through `forward_chain`'s delegation, was blocking legitimate short forwards (and a test had been rewritten to long text, masking it). Fixed by scoping the floor to `text_similarity` only; the forward-chain test was reverted to short text to prove it. The review also flagged that the low-score test no longer exercised the RapidFuzz path (fixed with ≥120-char bodies) and that prefetching attachments over the 30-day window was wasteful (removed in favor of lazy queries).

## Validation

- 21 unit tests in `test_email_merge.py` (incl. new: short-text no-merge, short-exact still merges, short forward still merges, disjoint-image block, shared-image allow, thread_relation wins); 25 across all merge unit files; 4 integration tests. All pass.
- `flake8` clean on `email_merge.py`; test-file `F841` unchanged from the pre-existing baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012RKBwEuSDcdc4dHZoZRrCt
