### PR TITLE
Remove redundant SMTP/STARTTLS fields from IMAP email config

### DIFF
--- a/devify/accounts/services/user_bootstrap.py
+++ b/devify/accounts/services/user_bootstrap.py
@@ -38,13 +38,10 @@ class UserBootstrapService:
             "mode": "auto_assign",
             "imap_config": {
                 "imap_host": "",
-                "smtp_ssl_port": 465,
-                "smtp_starttls_port": 587,
                 "imap_ssl_port": 993,
                 "username": "",
                 "password": "",
                 "use_ssl": True,
-                "use_starttls": False,
                 "delete_after_fetch": False,
             },
             "filter_config": {

--- a/devify/threadline/management/commands/init_threadline_settings.py
+++ b/devify/threadline/management/commands/init_threadline_settings.py
@@ -342,13 +342,10 @@ class Command(BaseCommand):
             "mode": "auto_assign",
             "imap_config": {
                 "imap_host": "your-imap-server-hostname",
-                "smtp_ssl_port": 465,
-                "smtp_starttls_port": 587,
                 "imap_ssl_port": 993,
                 "username": "your-email-username",
                 "password": "your-email-password",
                 "use_ssl": True,
-                "use_starttls": False,
                 "delete_after_fetch": False,
             },
             "filter_config": {

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -553,7 +553,6 @@
     "maxAgeDays": "Fetch only the last N days",
     "maxAgeDaysPlaceholder": "7",
     "useSsl": "Use SSL",
-    "useStarttls": "Use STARTTLS",
     "deleteAfterFetch": "Delete server mail after fetch",
     "imapFilters": "Filter rules",
     "imapFiltersPlaceholder": "One per line, e.g. unread, from:someone[at]example.com",

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -563,7 +563,6 @@
     "maxAgeDays": "仅抓取最近 N 天",
     "maxAgeDaysPlaceholder": "7",
     "useSsl": "使用 SSL",
-    "useStarttls": "使用 STARTTLS",
     "deleteAfterFetch": "抓取后删除服务器邮件",
     "imapFilters": "筛选规则",
     "imapFiltersPlaceholder": "每行一条，例如 unread、from:someone[at]example.com",

--- a/ui/src/pages/Settings.vue
+++ b/ui/src/pages/Settings.vue
@@ -630,15 +630,6 @@
 
                 <label class="flex items-center gap-2 text-sm text-gray-700">
                   <input
-                    v-model="emailForm.useStarttls"
-                    type="checkbox"
-                    class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
-                  />
-                  {{ t('settings.useStarttls') }}
-                </label>
-
-                <label class="flex items-center gap-2 text-sm text-gray-700">
-                  <input
                     v-model="emailForm.deleteAfterFetch"
                     type="checkbox"
                     class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
@@ -866,7 +857,6 @@ const emailForm = reactive({
   password: '',
   imapSslPort: 993,
   useSsl: true,
-  useStarttls: false,
   deleteAfterFetch: false,
   folder: 'INBOX',
   filtersText: '',
@@ -1006,7 +996,6 @@ function normalizeEmailConfig(value) {
   emailForm.imapSslPort = imapConfig.imap_ssl_port || 993
   emailForm.useSsl =
     imapConfig.use_ssl !== undefined ? Boolean(imapConfig.use_ssl) : true
-  emailForm.useStarttls = Boolean(imapConfig.use_starttls)
   emailForm.deleteAfterFetch = Boolean(imapConfig.delete_after_fetch)
   emailForm.folder = filterConfig.folder || 'INBOX'
   emailForm.filtersText = formatListValue(filterConfig.filters)
@@ -1024,7 +1013,6 @@ function buildEmailConfig() {
       password: emailForm.password,
       imap_ssl_port: Number(emailForm.imapSslPort) || 993,
       use_ssl: Boolean(emailForm.useSsl),
-      use_starttls: Boolean(emailForm.useStarttls),
       delete_after_fetch: Boolean(emailForm.deleteAfterFetch)
     },
     filter_config: {


### PR DESCRIPTION
Cleans up the default `imap_config` template so it only carries fields the IMAP fetch path actually uses.

## What changed
- Drop `smtp_ssl_port` (465) and `smtp_starttls_port` (587) — SMTP *sending* ports that have no place in an IMAP *receiving* config and are referenced nowhere.
- Drop `use_starttls` — persisted by the Settings UI but never read by the IMAP client (`imap.py` only consults `use_ssl`); STARTTLS is not implemented for IMAP fetch, so the toggle was a no-op. Removed the toggle from `Settings.vue` and the `settings.useStarttls` locale strings.

The IMAP client only reads: `imap_host`, `imap_ssl_port`, `use_ssl`, `username`, `password`, `delete_after_fetch`, `folder`.

## Files
- `devify/accounts/services/user_bootstrap.py`
- `devify/threadline/management/commands/init_threadline_settings.py`
- `ui/src/pages/Settings.vue`
- `ui/src/locales/{en,zh-CN}.json`

## Notes
Existing users' stored `imap_config` keeps these stale keys but they are inert (nothing reads them). An optional data migration to strip them can be a follow-up.

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)