### PR TITLE
Honor Relay channel language during delivery

### DIFF
--- a/devify/relay/services/adapters.py
+++ b/devify/relay/services/adapters.py
@@ -15,6 +15,7 @@ from relay.services.delivery_strategy import (
     UPDATE,
     resolve_delivery_plan,
 )
+from relay.services.localization import get_delivery_artifact
 
 
 @dataclass
@@ -150,7 +151,11 @@ class FeishuBitableRelayAdapter(BaseRelayAdapter):
             if hasattr(delivery, "metadata")
             else None
         ) or resolve_delivery_plan(subscription, event, delivery)
-        snapshot = event.artifact_snapshot or {}
+        snapshot = get_delivery_artifact(
+            event=event,
+            subscription=subscription,
+            delivery=delivery,
+        )
         title = _apply_feishu_title_prefix(
             subscription,
             snapshot.get("summary_title") or event.email_message.subject,
@@ -243,7 +248,11 @@ class JiraRelayAdapter(BaseRelayAdapter):
             if hasattr(delivery, "metadata")
             else None
         ) or resolve_delivery_plan(subscription, event, delivery)
-        snapshot = event.artifact_snapshot or {}
+        snapshot = get_delivery_artifact(
+            event=event,
+            subscription=subscription,
+            delivery=delivery,
+        )
         issue_data = {
             "title": snapshot.get("summary_title") or event.email_message.subject,
             "description": snapshot.get("summary_content")
@@ -352,7 +361,11 @@ class GitHubIssueRelayAdapter(BaseRelayAdapter):
             if hasattr(delivery, "metadata")
             else None
         ) or resolve_delivery_plan(subscription, event, delivery)
-        snapshot = event.artifact_snapshot or {}
+        snapshot = get_delivery_artifact(
+            event=event,
+            subscription=subscription,
+            delivery=delivery,
+        )
         issue_data = {
             "title": snapshot.get("summary_title") or event.email_message.subject,
             "description": snapshot.get("summary_content")

--- a/devify/relay/services/localization.py
+++ b/devify/relay/services/localization.py
@@ -1,0 +1,153 @@
+"""Per-delivery localization for Relay artifacts."""
+
+from __future__ import annotations
+
+import json
+import logging
+from copy import deepcopy
+from typing import Any, Dict
+
+from core.tracking import LLMTracker
+from relay.models import RelayAppConfig
+from threadline.utils.llm import parse_json_response
+
+logger = logging.getLogger(__name__)
+
+LOCALIZATION_METADATA_KEY = "relay_localization"
+TRANSLATABLE_FIELDS = (
+    "summary_title",
+    "summary_content",
+    "llm_content",
+    "summary_data",
+    "todos",
+)
+
+
+def normalize_language(value: Any) -> str:
+    """Normalize supported language aliases to their Relay display names."""
+    language = str(value or "").strip()
+    normalized = language.casefold().replace("_", "-")
+    if normalized == "chinese" or normalized.startswith("zh"):
+        return "Chinese"
+    if normalized == "english" or normalized.startswith("en"):
+        return "English"
+    return ""
+
+
+def _cache_localization(delivery, localization: Dict[str, Any]) -> None:
+    delivery.metadata = {
+        **(getattr(delivery, "metadata", None) or {}),
+        LOCALIZATION_METADATA_KEY: localization,
+    }
+    save = getattr(delivery, "save", None)
+    if callable(save):
+        save(update_fields=["metadata", "updated_at"])
+
+
+def _configured_model_uuid() -> str | None:
+    app_config = RelayAppConfig.objects.filter(workflow_key="relay").first()
+    if app_config and not app_config.is_active:
+        raise RuntimeError("Relay localization is disabled")
+    if app_config and app_config.llm_config_uuid:
+        return str(app_config.llm_config_uuid)
+    return None
+
+
+def _parse_localized_response(response: Any) -> Dict[str, Any]:
+    if isinstance(response, dict):
+        return response
+    if isinstance(response, str):
+        return parse_json_response(response)
+    raise ValueError("Relay localization returned an unsupported response type")
+
+
+def _translate_artifact(
+    artifact: Dict[str, Any],
+    *,
+    source_language: str,
+    target_language: str,
+) -> Dict[str, Any]:
+    content = {
+        key: artifact[key]
+        for key in TRANSLATABLE_FIELDS
+        if artifact.get(key) not in (None, "", [], {})
+    }
+    if not content:
+        return {**artifact, "language": target_language}
+
+    prompt = (
+        "Localize the supplied Relay delivery artifact into "
+        f"{target_language}. Its source language is "
+        f"{source_language or 'unknown'}. Translate every human-readable string, including "
+        "strings nested in objects and arrays, while preserving JSON structure, "
+        "Markdown, URLs, identifiers, issue keys, and technical names. Return only "
+        "one JSON object containing exactly the same keys as the supplied artifact. "
+        "Do not add commentary."
+    )
+    response, _usage = LLMTracker.call_and_track(
+        prompt=prompt,
+        content=json.dumps(content, ensure_ascii=False),
+        json_mode=True,
+        node_name="relay_localization",
+        model_uuid=_configured_model_uuid(),
+    )
+    translated = _parse_localized_response(response)
+    localized = deepcopy(artifact)
+    for key, original_value in content.items():
+        translated_value = translated.get(key)
+        if not isinstance(translated_value, type(original_value)):
+            raise ValueError(f"Relay localization omitted or changed type for {key}")
+        if isinstance(translated_value, str) and not translated_value.strip():
+            raise ValueError(f"Relay localization returned empty text for {key}")
+        localized[key] = translated_value
+    localized["language"] = target_language
+    return localized
+
+
+def get_delivery_artifact(*, event, subscription, delivery) -> Dict[str, Any]:
+    """Return a stable, channel-local artifact without mutating the event snapshot."""
+    metadata = getattr(delivery, "metadata", None) or {}
+    cached = metadata.get(LOCALIZATION_METADATA_KEY) or {}
+    cached_artifact = cached.get("artifact")
+    if isinstance(cached_artifact, dict):
+        return deepcopy(cached_artifact)
+
+    artifact = deepcopy(getattr(event, "artifact_snapshot", None) or {})
+    if not artifact.get("summary_title"):
+        artifact["summary_title"] = str(
+            getattr(getattr(event, "email_message", None), "subject", "") or ""
+        ).strip()
+
+    config = getattr(subscription, "config", None) or {}
+    target_language = normalize_language(config.get("language"))
+    source_language = normalize_language(artifact.get("language"))
+    if not target_language or target_language == source_language:
+        return artifact
+
+    status = "localized"
+    try:
+        localized = _translate_artifact(
+            artifact,
+            source_language=source_language,
+            target_language=target_language,
+        )
+    except Exception:
+        logger.exception(
+            "Relay artifact localization failed; using source artifact "
+            "delivery=%s target_language=%s",
+            getattr(delivery, "id", None),
+            target_language,
+        )
+        localized = artifact
+        status = "fallback"
+
+    _cache_localization(
+        delivery,
+        {
+            "status": status,
+            "source_language": source_language,
+            "target_language": target_language,
+            "artifact": localized,
+        },
+    )
+    return deepcopy(localized)

--- a/devify/relay/tests/test_localization.py
+++ b/devify/relay/tests/test_localization.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from relay.models import RelaySubscription
+from relay.services.adapters import (
+    FeishuBitableRelayAdapter,
+    GitHubIssueRelayAdapter,
+    JiraRelayAdapter,
+)
+from relay.services.localization import get_delivery_artifact, normalize_language
+
+
+class _FakeDelivery(SimpleNamespace):
+    def save(self, *, update_fields):
+        self.saved_update_fields = update_fields
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("English", "English"),
+        ("en-US", "English"),
+        ("zh_CN", "Chinese"),
+        ("Spanish", ""),
+    ],
+)
+def test_normalize_language_supports_relay_language_aliases(value, expected):
+    assert normalize_language(value) == expected
+
+
+def test_delivery_artifact_localizes_per_channel_and_reuses_cached_result(
+    monkeypatch,
+):
+    event = SimpleNamespace(
+        email_message=SimpleNamespace(subject="登录页面无法打开"),
+        artifact_snapshot={
+            "summary_title": "登录页面无法打开",
+            "summary_content": "用户报告登录页面返回空白。",
+            "llm_content": "用户报告登录页面返回空白。",
+            "language": "Chinese",
+        },
+    )
+    english_subscription = SimpleNamespace(
+        target_type=RelaySubscription.TargetType.JIRA,
+        config={"language": "en", "jira": {}},
+    )
+    chinese_subscription = SimpleNamespace(
+        target_type=RelaySubscription.TargetType.FEISHU_BITABLE,
+        config={"language": "Chinese", "feishu_bitable": {}},
+    )
+    english_delivery = _FakeDelivery(id=1, metadata={})
+    chinese_delivery = _FakeDelivery(id=2, metadata={})
+    llm_calls = []
+
+    def fake_call_and_track(**kwargs):
+        llm_calls.append(kwargs)
+        return (
+            {
+                "summary_title": "Login page does not open",
+                "summary_content": "The user reports a blank login page.",
+                "llm_content": "The user reports a blank login page.",
+            },
+            {"total_tokens": 10},
+        )
+
+    monkeypatch.setattr(
+        "relay.services.localization.LLMTracker.call_and_track",
+        fake_call_and_track,
+    )
+    monkeypatch.setattr(
+        "relay.services.localization._configured_model_uuid",
+        lambda: None,
+    )
+
+    english_artifact = get_delivery_artifact(
+        event=event,
+        subscription=english_subscription,
+        delivery=english_delivery,
+    )
+    chinese_artifact = get_delivery_artifact(
+        event=event,
+        subscription=chinese_subscription,
+        delivery=chinese_delivery,
+    )
+    cached_english_artifact = get_delivery_artifact(
+        event=event,
+        subscription=english_subscription,
+        delivery=english_delivery,
+    )
+
+    assert english_artifact["summary_title"] == "Login page does not open"
+    assert english_artifact["summary_content"] == (
+        "The user reports a blank login page."
+    )
+    assert english_artifact["language"] == "English"
+    assert chinese_artifact["summary_title"] == "登录页面无法打开"
+    assert cached_english_artifact == english_artifact
+    assert len(llm_calls) == 1
+    assert event.artifact_snapshot["summary_title"] == "登录页面无法打开"
+
+    assert english_delivery.metadata["relay_localization"]["status"] == "localized"
+    assert english_delivery.metadata["relay_localization"]["artifact"] == (
+        english_artifact
+    )
+    assert english_delivery.saved_update_fields == ["metadata", "updated_at"]
+
+
+def test_delivery_artifact_caches_original_artifact_when_localization_fails(
+    monkeypatch,
+):
+    event = SimpleNamespace(
+        email_message=SimpleNamespace(subject="支付失败"),
+        artifact_snapshot={
+            "summary_title": "支付失败",
+            "summary_content": "用户无法完成支付。",
+            "language": "Chinese",
+        },
+    )
+    subscription = SimpleNamespace(
+        target_type=RelaySubscription.TargetType.GITHUB_ISSUE,
+        config={"language": "English", "github": {}},
+    )
+    delivery = _FakeDelivery(id=3, metadata={})
+    llm_calls = []
+
+    def fail_localization(**kwargs):
+        llm_calls.append(kwargs)
+        raise RuntimeError("LLM unavailable")
+
+    monkeypatch.setattr(
+        "relay.services.localization.LLMTracker.call_and_track",
+        fail_localization,
+    )
+    monkeypatch.setattr(
+        "relay.services.localization._configured_model_uuid",
+        lambda: None,
+    )
+
+    first_artifact = get_delivery_artifact(
+        event=event,
+        subscription=subscription,
+        delivery=delivery,
+    )
+    second_artifact = get_delivery_artifact(
+        event=event,
+        subscription=subscription,
+        delivery=delivery,
+    )
+
+    assert first_artifact["summary_title"] == "支付失败"
+    assert second_artifact == first_artifact
+    assert len(llm_calls) == 1
+    assert delivery.metadata["relay_localization"]["status"] == "fallback"
+
+
+@pytest.mark.parametrize(
+    ("adapter_class", "handler_path", "target_type"),
+    [
+        (
+            FeishuBitableRelayAdapter,
+            "relay.services.drivers.feishu_bitable_handler.FeishuBitableIssueHandler",
+            RelaySubscription.TargetType.FEISHU_BITABLE,
+        ),
+        (
+            JiraRelayAdapter,
+            "relay.services.adapters.JiraIssueHandler",
+            RelaySubscription.TargetType.JIRA,
+        ),
+        (
+            GitHubIssueRelayAdapter,
+            "relay.services.adapters.GitHubIssueHandler",
+            RelaySubscription.TargetType.GITHUB_ISSUE,
+        ),
+    ],
+)
+def test_relay_adapters_use_delivery_localized_title_content_and_language(
+    monkeypatch,
+    adapter_class,
+    handler_path,
+    target_type,
+):
+    captured = {}
+
+    class FakeHandler:
+        repo = "cloud2ai/devify"
+
+        def __init__(self, config):
+            self.config = config
+
+        def create_issue(self, **kwargs):
+            captured.update(kwargs)
+            return "external-1"
+
+        def get_issue_url(self, external_id):
+            return f"https://example.com/{external_id}"
+
+    monkeypatch.setattr(handler_path, FakeHandler)
+    monkeypatch.setattr(
+        "relay.services.localization.LLMTracker.call_and_track",
+        lambda **kwargs: (
+            {
+                "summary_title": "Localized title",
+                "summary_content": "Localized content",
+                "llm_content": "Localized content",
+            },
+            {"total_tokens": 10},
+        ),
+    )
+    monkeypatch.setattr(
+        "relay.services.localization._configured_model_uuid",
+        lambda: None,
+    )
+
+    event = SimpleNamespace(
+        id=1,
+        email_message_id=1,
+        email_message=SimpleNamespace(subject="原始标题"),
+        artifact_snapshot={
+            "summary_title": "原始标题",
+            "summary_content": "原始内容",
+            "llm_content": "原始内容",
+            "language": "Chinese",
+        },
+    )
+    subscription = SimpleNamespace(
+        target_type=target_type,
+        config={"language": "English"},
+        strategies={},
+    )
+    delivery = SimpleNamespace(
+        external_id=None,
+        metadata={
+            "relay_delivery_plan": {
+                "action": "new",
+                "source": "test",
+                "reference_external_id": "",
+                "related_issue_keys": [],
+                "related_issue_references": [],
+                "linking_supported": False,
+            }
+        },
+    )
+
+    adapter_class().deliver(
+        event=event,
+        subscription=subscription,
+        delivery=delivery,
+    )
+
+    assert captured["issue_data"]["title"] == "Localized title"
+    assert captured["issue_data"]["description"] == "Localized content"
+    assert captured["email_data"]["language"] == "English"

--- a/ui/src/composables/useRelayEditor.js
+++ b/ui/src/composables/useRelayEditor.js
@@ -446,6 +446,10 @@ export function useRelayEditor({ reloadAll, activeTab }) {
       }
     }
 
+    const sourceLanguage =
+      editorForm.language === 'English' ? 'Chinese' : 'English'
+    const sourceIsChinese = sourceLanguage === 'Chinese'
+
     return {
       subscription: {
         target_type: editorForm.target_type || 'feishu_bitable',
@@ -456,10 +460,16 @@ export function useRelayEditor({ reloadAll, activeTab }) {
         field_mappings: buildFieldMappingsFromRows(editorForm.fieldMappingRows)
       },
       artifact_snapshot: {
-        summary_title: 'devify test summary',
-        summary_content: 'devify test description',
-        llm_content: 'devify test description',
-        language: editorForm.language || 'Chinese'
+        summary_title: sourceIsChinese
+          ? 'devify 测试摘要'
+          : 'devify test summary',
+        summary_content: sourceIsChinese
+          ? 'devify 测试描述'
+          : 'devify test description',
+        llm_content: sourceIsChinese
+          ? 'devify 测试描述'
+          : 'devify test description',
+        language: sourceLanguage
       }
     }
   }

--- a/ui/src/composables/useRelayEditor.spec.js
+++ b/ui/src/composables/useRelayEditor.spec.js
@@ -42,6 +42,7 @@ describe('useRelayEditor GitHub Issue target', () => {
   it('builds a GitHub test payload with repo credentials and mappings', () => {
     const { editorForm, buildTestPayload } = createEditor()
     editorForm.target_type = 'github_issue'
+    editorForm.language = 'English'
     editorForm.githubConfig.repo = 'cloud2ai/devify'
     editorForm.githubConfig.token = 'github-token'
     editorForm.githubConfig.labels_text = 'relay\nneeds-review'
@@ -51,12 +52,18 @@ describe('useRelayEditor GitHub Issue target', () => {
 
     expect(payload.subscription.config).toMatchObject({
       issue_engine: 'github_issue',
+      language: 'English',
       github: {
         repo: 'cloud2ai/devify',
         token: 'github-token',
         labels: ['relay', 'needs-review'],
         assignees: ['octocat', 'hubot']
       }
+    })
+    expect(payload.artifact_snapshot).toMatchObject({
+      summary_title: 'devify 测试摘要',
+      summary_content: 'devify 测试描述',
+      language: 'Chinese'
     })
   })
 


### PR DESCRIPTION
## Summary
- Localize Relay delivery artifacts to each channel's configured language without mutating the shared event snapshot
- Cache localized or fallback artifacts per delivery so retries and updates keep stable titles and content
- Apply the behavior consistently to Feishu Bitable, Jira, and GitHub Issues, and make channel tests exercise a different source language

Closes #24

## Test plan
- [x] `docker run --rm --entrypoint pytest ... relay/tests/test_localization.py -q` (9 passed)
- [x] `npx vitest run src/composables/useRelayEditor.spec.js` (3 passed)
- [x] `npx eslint src/composables/useRelayEditor.js src/composables/useRelayEditor.spec.js`