### PR TITLE
Append email source labels to GitHub issue delivery

### DIFF
--- a/devify/relay/services/adapters.py
+++ b/devify/relay/services/adapters.py
@@ -374,6 +374,8 @@ class GitHubIssueRelayAdapter(BaseRelayAdapter):
         }
         email_data = {
             "id": str(event.email_message_id),
+            "sender": getattr(event.email_message, "sender", "") or "",
+            "recipients": getattr(event.email_message, "recipients", "") or "",
             "subject": event.email_message.subject,
             "summary_title": snapshot.get("summary_title")
             or event.email_message.subject,

--- a/devify/relay/tests/unit/test_github_issue_handler.py
+++ b/devify/relay/tests/unit/test_github_issue_handler.py
@@ -144,6 +144,85 @@ def test_create_issue_embeds_related_issue_references(github_config):
     assert "- #12" in body
 
 
+def test_create_issue_appends_email_source_labels(github_config):
+    session = Mock()
+    session.request.return_value = _response(
+        status_code=201,
+        payload={"number": 50},
+    )
+    handler = GitHubIssueHandler(github_config, session=session)
+
+    handler.create_issue(
+        issue_data={"title": "Source labels", "description": "Body"},
+        email_data={
+            "sender": "Alice <alice@example.com>",
+            "recipients": "Bob <bob@example.com>, ops@example.com",
+        },
+        attachments=[],
+    )
+
+    labels = session.request.call_args.kwargs["json"]["labels"]
+    assert labels == [
+        "relay",
+        "needs-review",
+        "sender:alice@example.com",
+        "recipient:bob@example.com",
+        "recipient:ops@example.com",
+    ]
+
+
+def test_create_issue_sanitizes_deduplicates_and_truncates_source_labels():
+    config = {
+        "github": {
+            "repo": "cloud2ai/devify",
+            "token": "test-token",
+            "labels": ["sender:alice@example.com"],
+        }
+    }
+    session = Mock()
+    session.request.return_value = _response(
+        status_code=201,
+        payload={"number": 51},
+    )
+    handler = GitHubIssueHandler(config, session=session)
+
+    long_address = "a" * 60 + "@example.com"
+    handler.create_issue(
+        issue_data={"title": "Labels", "description": "Body"},
+        email_data={
+            "sender": "Alice <alice@example.com>",
+            "recipients": f"ops@example.com, {long_address}",
+        },
+        attachments=[],
+    )
+
+    labels = session.request.call_args.kwargs["json"]["labels"]
+    assert labels == [
+        "sender:alice@example.com",
+        "recipient:ops@example.com",
+        ("recipient:" + long_address)[:50],
+    ]
+    assert all(len(label) <= 50 for label in labels)
+
+
+def test_update_issue_keeps_email_source_labels(github_config):
+    session = Mock()
+    session.request.return_value = _response(
+        payload={"number": 42},
+    )
+    handler = GitHubIssueHandler(github_config, session=session)
+
+    handler.update_issue(
+        "42",
+        issue_data={"title": "Updated title", "description": "Updated body"},
+        email_data={"sender": "Alice <alice@example.com>"},
+        attachments=[],
+    )
+
+    labels = session.request.call_args.kwargs["json"]["labels"]
+    assert "sender:alice@example.com" in labels
+
+
 def test_create_issue_truncates_body_to_github_limit(github_config):
     session = Mock()
     session.request.return_value = _response(
@@ -245,7 +324,11 @@ def test_adapter_updates_existing_github_issue(monkeypatch, github_config):
         ),
     )
     event = SimpleNamespace(
-        email_message=SimpleNamespace(subject="Original subject"),
+        email_message=SimpleNamespace(
+            subject="Original subject",
+            sender="alice@example.com",
+            recipients="inbox@example.com",
+        ),
         email_message_id=7,
         artifact_snapshot={
             "summary_title": "Updated title",
@@ -293,6 +376,8 @@ def test_adapter_updates_existing_github_issue(monkeypatch, github_config):
     update_issue.assert_called_once()
     create_issue.assert_not_called()
     update_email_data = update_issue.call_args.kwargs["email_data"]
+    assert update_email_data["sender"] == "alice@example.com"
+    assert update_email_data["recipients"] == "inbox@example.com"
     assert update_email_data["related_issue_references"] == [
         {
             "external_id": "7",

--- a/devify/threadline/utils/issues/github_issue_handler.py
+++ b/devify/threadline/utils/issues/github_issue_handler.py
@@ -23,10 +23,12 @@ GITHUB_ISSUE_TRUNCATION_NOTICE = (
     "\n\n> [!NOTE]\n"
     "> This issue body was truncated because it exceeded GitHub's issue body limit.\n"
 )
+GITHUB_LABEL_MAX_LENGTH = 50
 REPOSITORY_PATTERN = re.compile(
     r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/[A-Za-z0-9_.-]+$"
 )
 IMAGE_PLACEHOLDER_PATTERN = re.compile(r"\[IMAGE:\s*([^\]]+)\]")
+EMAIL_ADDRESS_PATTERN = re.compile(r"<([^<>]+)>")
 
 
 def _string_list(value: Any, *, field_name: str) -> list[str]:
@@ -151,9 +153,52 @@ class GitHubIssueHandler:
         return {
             "title": title[:256],
             "body": body,
-            "labels": self.labels,
+            "labels": self._build_labels(email_data),
             "assignees": self.assignees,
         }
+
+    def _build_labels(self, email_data: Mapping[str, Any]) -> List[str]:
+        labels = list(self.labels)
+        known = {label.casefold() for label in labels}
+        for source_label in self._email_source_labels(email_data):
+            if source_label.casefold() not in known:
+                labels.append(source_label)
+                known.add(source_label.casefold())
+        return labels
+
+    def _email_source_labels(self, email_data: Mapping[str, Any]) -> List[str]:
+        labels: list[str] = []
+        sender = self._extract_email_address(email_data.get("sender"))
+        if sender:
+            labels.append(self._source_label("sender", sender))
+        recipients = str(email_data.get("recipients") or "").strip()
+        for recipient in recipients.split(","):
+            address = self._extract_email_address(recipient)
+            if address:
+                labels.append(self._source_label("recipient", address))
+        return [label for label in labels if label]
+
+    @classmethod
+    def _source_label(cls, prefix: str, value: str) -> str:
+        token = cls._label_token(value)
+        if not token:
+            return ""
+        return f"{prefix}:{token}"[:GITHUB_LABEL_MAX_LENGTH]
+
+    @staticmethod
+    def _label_token(value: str) -> str:
+        token = re.sub(r"[^A-Za-z0-9 _.:/@+-]", "-", str(value or "")).strip(" -_")
+        return token[:GITHUB_LABEL_MAX_LENGTH]
+
+    @staticmethod
+    def _extract_email_address(value: Any) -> str:
+        text = str(value or "").strip()
+        angle_match = EMAIL_ADDRESS_PATTERN.search(text)
+        if angle_match:
+            return angle_match.group(1).strip()
+        if "@" in text:
+            return text
+        return ""
 
     def _build_body(
         self,


### PR DESCRIPTION
## Summary
- Relay GitHub Issue target appends email-source labels on issue create/update: `sender:<email>` and one `recipient:<email>` per recipient
- Labels deduplicated against configured `labels` (case-insensitive), sanitized, and truncated to 50 chars
- `GitHubIssueRelayAdapter` passes `sender`/`recipients` from `EmailMessage` via `email_data`
- Adds unit tests for append, dedup, sanitize, truncate, and update paths

Closes #30

## Test plan
- [x] `pytest relay/tests/unit/test_github_issue_handler.py` — 15 passed (in dev container)