### PR TITLE
Update repository references after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 [![Django](https://img.shields.io/badge/backend-Django-092E20.svg?logo=django)](devify/)
 [![Vue 3](https://img.shields.io/badge/frontend-Vue%203-4FC08D.svg?logo=vuedotjs&logoColor=white)](ui/)
 [![Docker](https://img.shields.io/badge/deploy-Docker%20Compose-2496ED.svg?logo=docker&logoColor=white)](docker-compose.yml)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/cloud2ai/devify/pulls)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/oneprolabs/devify/pulls)
 
 **Enterprise-grade AI-powered conversation intelligence and data application platform**
 
 Turn fragmented conversations — chat records, email threads, screenshots — into structured summaries and reusable data, then deliver them to JIRA, knowledge bases, and workflow automation.
 
-[Quick Start](#-quick-start) · [Documentation](#-documentation) · [How It Works](#-how-devify-works) · [Recommended Providers](#-recommended-llm-providers) · [Self-Hosting](#-self-hosting-requirements) · [SaaS Edition](https://aimychats.com)
+[Quick Start](#-quick-start) · [One-command Installation](#-one-command-installation) · [Documentation](#-documentation) · [How It Works](#-how-devify-works) · [Recommended Providers](#-recommended-llm-providers) · [Self-Hosting](#-self-hosting-requirements) · [SaaS Edition](https://aimychats.com)
 
 English | [中文](README_ZH.md)
 
@@ -216,6 +216,70 @@ docker compose up -d
 
 The production compose file includes the full application stack: API, worker,
 scheduler, UI, MySQL, Redis, Nginx, and Haraka.
+
+### One-command Installation
+
+For a production-style self-hosted installation, `install.sh` downloads the
+release files directly, generates the initial configuration and secrets, pulls
+the Docker images, starts the complete stack, and verifies `/health`. It does
+not clone the Git repository.
+
+Requirements:
+
+- Docker with Compose (Docker Desktop is supported on macOS and Windows)
+- Linux: Ubuntu, Debian, Rocky, Alma, or CentOS; Windows: Git Bash
+- `amd64` or `arm64` CPU architecture
+- At least 2 GB available memory and 5 GB free disk space (4 GB RAM and 20 GB
+  disk are recommended)
+
+Run the installer on Linux or macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/devify/main/install.sh | sudo bash
+```
+
+On Windows, run the equivalent command from Git Bash; Docker Desktop must be
+installed and running:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/devify/main/install.sh | bash
+```
+
+For networks with limited GitHub access, use the China distribution channel:
+
+```bash
+curl -fsSL https://gitee.com/oneprolabs/devify/raw/main/install.sh | sudo bash -s -- \
+  --channel cn --download-source gitee
+```
+
+Both GitHub and Gitee use `oneprolabs/devify` as the source repository.
+
+The installer automatically selects an available download source and the
+Aliyun ACR image registry. To install Docker automatically on supported Linux
+distributions, add `--install-docker`. Use `--yes` for a non-interactive run:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/oneprolabs/devify/main/install.sh | \
+  sudo bash -s -- --channel cn --yes
+```
+
+Common options include `--dir /srv/devify`, `--port 8080`,
+`--admin-port 19443`, `--smtp-port 25`, `--domain dev.example.com`, and
+`--version 1.2.3`. Run `install.sh --help` for the complete list.
+
+After installation:
+
+- Main site: `http://<host>:8080`
+- Admin panel: `https://<host>:19443/admin` (self-signed certificate)
+- Configuration: `<install-dir>/.env`
+- Installation details and the initial admin password:
+  `<install-dir>/install-info.env`
+
+The default installation directory is `/opt/devify` on Linux/macOS and
+`$HOME/devify` on Windows Git Bash. Re-running the installer is safe: existing
+`.env` configuration and application data are preserved. Outbound email uses
+the console backend by default; configure SMTP in `.env` before relying on
+email notifications.
 
 ### Haraka Inbound Email
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -7,7 +7,7 @@
 [![Django](https://img.shields.io/badge/backend-Django-092E20.svg?logo=django)](devify/)
 [![Vue 3](https://img.shields.io/badge/frontend-Vue%203-4FC08D.svg?logo=vuedotjs&logoColor=white)](ui/)
 [![Docker](https://img.shields.io/badge/deploy-Docker%20Compose-2496ED.svg?logo=docker&logoColor=white)](docker-compose.yml)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/cloud2ai/devify/pulls)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/oneprolabs/devify/pulls)
 
 **企业级 AI 对话智能与数据应用平台**
 

--- a/devify/relay/tests/test_localization.py
+++ b/devify/relay/tests/test_localization.py
@@ -185,7 +185,7 @@ def test_relay_adapters_use_delivery_localized_title_content_and_language(
     captured = {}
 
     class FakeHandler:
-        repo = "cloud2ai/devify"
+        repo = "oneprolabs/devify"
 
         def __init__(self, config):
             self.config = config

--- a/devify/relay/tests/unit/test_delivery_strategy.py
+++ b/devify/relay/tests/unit/test_delivery_strategy.py
@@ -60,7 +60,7 @@ def test_auto_merge_strategy_update_resolves_to_update(monkeypatch):
             external_id="REQ-123",
             metadata={
                 "provider": "github_issue",
-                "github_repo": "cloud2ai/devify",
+                "github_repo": "oneprolabs/devify",
             },
         ),
     )
@@ -78,7 +78,7 @@ def test_auto_merge_strategy_update_resolves_to_update(monkeypatch):
     assert plan["action"] == "update"
     assert plan["source"] == "auto_merge"
     assert plan["reference_external_id"] == "REQ-123"
-    assert plan["reference_github_repo"] == "cloud2ai/devify"
+    assert plan["reference_github_repo"] == "oneprolabs/devify"
     assert plan["reference_provider"] == "github_issue"
     assert plan["related_issue_keys"] == []
 

--- a/devify/relay/tests/unit/test_github_issue_handler.py
+++ b/devify/relay/tests/unit/test_github_issue_handler.py
@@ -20,7 +20,7 @@ def github_config():
     return {
         "issue_engine": "github_issue",
         "github": {
-            "repo": "cloud2ai/devify",
+            "repo": "oneprolabs/devify",
             "token": "test-token",
             "labels": ["relay", "needs-review"],
             "assignees": ["octocat"],
@@ -48,7 +48,7 @@ def test_create_issue_posts_structured_markdown_and_public_attachment_urls(
         status_code=201,
         payload={
             "number": 42,
-            "html_url": "https://github.com/cloud2ai/devify/issues/42",
+            "html_url": "https://github.com/oneprolabs/devify/issues/42",
         },
     )
     handler = GitHubIssueHandler(github_config, session=session)
@@ -78,7 +78,7 @@ def test_create_issue_posts_structured_markdown_and_public_attachment_urls(
     request = session.request.call_args
     assert request.args == (
         "POST",
-        "https://api.github.com/repos/cloud2ai/devify/issues",
+        "https://api.github.com/repos/oneprolabs/devify/issues",
     )
     assert request.kwargs["timeout"] == 15
     assert request.kwargs["headers"]["Authorization"] == "Bearer test-token"
@@ -102,7 +102,7 @@ def test_update_issue_patches_the_existing_issue(github_config):
     session.request.return_value = _response(
         payload={
             "number": 42,
-            "html_url": "https://github.com/cloud2ai/devify/issues/42",
+            "html_url": "https://github.com/oneprolabs/devify/issues/42",
         }
     )
     handler = GitHubIssueHandler(github_config, session=session)
@@ -118,7 +118,7 @@ def test_update_issue_patches_the_existing_issue(github_config):
     request = session.request.call_args
     assert request.args == (
         "PATCH",
-        "https://api.github.com/repos/cloud2ai/devify/issues/42",
+        "https://api.github.com/repos/oneprolabs/devify/issues/42",
     )
     assert request.kwargs["json"]["title"] == "Updated title"
     assert request.kwargs["json"]["body"] == "Updated body"
@@ -174,7 +174,7 @@ def test_create_issue_appends_email_source_labels(github_config):
 def test_create_issue_sanitizes_deduplicates_and_truncates_source_labels():
     config = {
         "github": {
-            "repo": "cloud2ai/devify",
+            "repo": "oneprolabs/devify",
             "token": "test-token",
             "labels": ["sender:alice@example.com"],
         }
@@ -296,11 +296,11 @@ def test_create_issue_omits_attachment_paths_outside_public_storage(
 def test_handler_rejects_invalid_repo_and_missing_token():
     with pytest.raises(ValueError, match="owner/name"):
         GitHubIssueHandler(
-            {"github": {"repo": "https://github.com/cloud2ai/devify", "token": "x"}}
+            {"github": {"repo": "https://github.com/oneprolabs/devify", "token": "x"}}
         )
 
     with pytest.raises(ValueError, match="token"):
-        GitHubIssueHandler({"github": {"repo": "cloud2ai/devify", "token": ""}})
+        GitHubIssueHandler({"github": {"repo": "oneprolabs/devify", "token": ""}})
 
 
 def test_factory_and_registry_resolve_github_target(github_config):
@@ -320,7 +320,7 @@ def test_adapter_updates_existing_github_issue(monkeypatch, github_config):
         GitHubIssueHandler,
         "get_issue_url",
         lambda self, issue_number: (
-            f"https://github.com/cloud2ai/devify/issues/{issue_number}"
+            f"https://github.com/oneprolabs/devify/issues/{issue_number}"
         ),
     )
     event = SimpleNamespace(
@@ -354,12 +354,12 @@ def test_adapter_updates_existing_github_issue(monkeypatch, github_config):
                     {
                         "external_id": "42",
                         "provider": "github_issue",
-                        "github_repo": "cloud2ai/devify",
+                        "github_repo": "oneprolabs/devify",
                     },
                     {
                         "external_id": "7",
                         "provider": "github_issue",
-                        "github_repo": "cloud2ai/devify",
+                        "github_repo": "oneprolabs/devify",
                     },
                 ],
                 "linking_supported": True,
@@ -382,13 +382,13 @@ def test_adapter_updates_existing_github_issue(monkeypatch, github_config):
         {
             "external_id": "7",
             "provider": "github_issue",
-            "github_repo": "cloud2ai/devify",
+            "github_repo": "oneprolabs/devify",
         }
     ]
     assert result.external_id == "42"
     assert result.external_url.endswith("/issues/42")
     assert result.metadata["provider"] == "github_issue"
-    assert result.metadata["github_repo"] == "cloud2ai/devify"
+    assert result.metadata["github_repo"] == "oneprolabs/devify"
     assert result.metadata["relay_strategy"] == "update"
 
 
@@ -469,8 +469,8 @@ def test_adapter_creates_new_issue_when_reference_target_changed(
         create_email_data = create_issue.call_args.kwargs["email_data"]
         assert create_email_data["related_issue_references"][0]["external_id"] == "42"
     assert result.external_id == "99"
-    assert result.external_url == "https://github.com/cloud2ai/devify/issues/99"
-    assert result.metadata["github_repo"] == "cloud2ai/devify"
+    assert result.external_url == "https://github.com/oneprolabs/devify/issues/99"
+    assert result.metadata["github_repo"] == "oneprolabs/devify"
 
 
 def test_subscription_serializer_validates_github_config_shape(github_config):
@@ -489,7 +489,7 @@ def test_subscription_serializer_validates_github_config_shape(github_config):
             "name": "GitHub",
             "config": {
                 "github": {
-                    "repo": "cloud2ai/devify",
+                    "repo": "oneprolabs/devify",
                     "token": "token",
                     "labels": "relay",
                 }

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@
 #     and Windows via Git Bash (all require Docker; Docker Desktop works)
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/cloud2ai/devify/main/install.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/oneprolabs/devify/main/install.sh | sudo bash
 #   sudo bash install.sh [options]   # see --help
 # =============================================================================
 
@@ -25,10 +25,10 @@ set -Eeuo pipefail
 # ---------------------------------------------------------------------------
 APP_NAME="devify"
 APP_TITLE="Devify"
-GITHUB_REPO="cloud2ai/devify"
+GITHUB_REPO="oneprolabs/devify"
 GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}"
 GITHUB_RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPO}"
-GITEE_REPO="${GITHUB_REPO}"
+GITEE_REPO="oneprolabs/devify"
 GITEE_API="https://gitee.com/api/v5/repos/${GITEE_REPO}"
 GITEE_RAW_BASE="https://gitee.com/${GITEE_REPO}/raw"
 DEFAULT_INSTALL_DIR="/opt/${APP_NAME}"

--- a/ui/src/composables/useRelayEditor.spec.js
+++ b/ui/src/composables/useRelayEditor.spec.js
@@ -43,7 +43,7 @@ describe('useRelayEditor GitHub Issue target', () => {
     const { editorForm, buildTestPayload } = createEditor()
     editorForm.target_type = 'github_issue'
     editorForm.language = 'English'
-    editorForm.githubConfig.repo = 'cloud2ai/devify'
+    editorForm.githubConfig.repo = 'oneprolabs/devify'
     editorForm.githubConfig.token = 'github-token'
     editorForm.githubConfig.labels_text = 'relay\nneeds-review'
     editorForm.githubConfig.assignees_text = 'octocat\nhubot'
@@ -54,7 +54,7 @@ describe('useRelayEditor GitHub Issue target', () => {
       issue_engine: 'github_issue',
       language: 'English',
       github: {
-        repo: 'cloud2ai/devify',
+        repo: 'oneprolabs/devify',
         token: 'github-token',
         labels: ['relay', 'needs-review'],
         assignees: ['octocat', 'hubot']
@@ -80,7 +80,7 @@ describe('useRelayEditor GitHub Issue target', () => {
       config: {
         language: 'English',
         github: {
-          repo: 'cloud2ai/devify',
+          repo: 'oneprolabs/devify',
           token: 'github-token',
           labels: ['relay', 'bug'],
           assignees: ['octocat']
@@ -89,7 +89,7 @@ describe('useRelayEditor GitHub Issue target', () => {
     })
 
     expect(editorForm.githubConfig).toEqual({
-      repo: 'cloud2ai/devify',
+      repo: 'oneprolabs/devify',
       token: 'github-token',
       labels_text: 'relay\nbug',
       assignees_text: 'octocat'
@@ -101,7 +101,7 @@ describe('useRelayEditor GitHub Issue target', () => {
     const { editorForm, persistEditor } = createEditor()
     editorForm.target_type = 'github_issue'
     editorForm.name = 'Devify GitHub'
-    editorForm.githubConfig.repo = 'cloud2ai/devify'
+    editorForm.githubConfig.repo = 'oneprolabs/devify'
     editorForm.githubConfig.token = 'github-token'
     editorForm.githubConfig.labels_text = 'relay\nfeature'
     editorForm.githubConfig.assignees_text = 'octocat'
@@ -114,7 +114,7 @@ describe('useRelayEditor GitHub Issue target', () => {
         config: expect.objectContaining({
           issue_engine: 'github_issue',
           github: {
-            repo: 'cloud2ai/devify',
+            repo: 'oneprolabs/devify',
             token: 'github-token',
             labels: ['relay', 'feature'],
             assignees: ['octocat']

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -188,7 +188,7 @@
     "githubConfigTitle": "GitHub Issue config",
     "githubConfigHelp": "Use a fine-grained personal access token with Issues write access to the target repository.",
     "githubRepo": "Repository",
-    "githubRepoPlaceholder": "e.g. cloud2ai/devify",
+    "githubRepoPlaceholder": "e.g. oneprolabs/devify",
     "githubRepoHelp": "Enter the repository in owner/name format.",
     "githubToken": "Personal access token",
     "githubTokenPlaceholder": "Enter a fine-grained GitHub token",

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -188,7 +188,7 @@
     "githubConfigTitle": "GitHub Issue 配置",
     "githubConfigHelp": "请使用对目标仓库拥有 Issues 写权限的细粒度个人访问 Token。",
     "githubRepo": "仓库",
-    "githubRepoPlaceholder": "例如 cloud2ai/devify",
+    "githubRepoPlaceholder": "例如 oneprolabs/devify",
     "githubRepoHelp": "请使用 owner/name 格式填写仓库。",
     "githubToken": "个人访问 Token",
     "githubTokenPlaceholder": "输入细粒度 GitHub Token",


### PR DESCRIPTION
## Summary

- Update installer, documentation, relay tests, and UI fixtures from `cloud2ai/devify` to `oneprolabs/devify`.
- Document one-command installation and the GitHub/Gitee distribution sources.
- Keep repository references consistent for GitHub Issue relay configuration and tests.

Closes #38

## Test plan

- [x] `npx vitest run src/composables/useRelayEditor.spec.js` (3 passed)
- [x] `git diff --check`
- [ ] Backend relay tests — host pytest environment is missing `dj_rest_auth`; the existing development API container is stopped, so no extra test container was created.