### PR TITLE
Harden installer after end-to-end feedback

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -63,7 +63,7 @@ jobs:
             USE_MIRROR=false
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Extract metadata for UI image
         id: ui-meta
@@ -93,7 +93,27 @@ jobs:
             VITE_SENTRY_RELEASE=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
+
+      - name: Verify published image platforms
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_VERSION#v}"
+          for image_name in "${IMAGE_NAME}" "${UI_IMAGE_NAME}"; do
+            image="${ALIYUN_REGISTRY}/${image_name}:${version}"
+            manifest="$(docker buildx imagetools inspect --raw "${image}")"
+            for arch in amd64 arm64; do
+              if ! printf '%s' "${manifest}" | jq -e --arg arch "${arch}" \
+                'any(.manifests[]?; .platform.os == "linux" and .platform.architecture == $arch)' \
+                >/dev/null; then
+                echo "Missing linux/${arch} manifest in ${image}" >&2
+                exit 1
+              fi
+            done
+            echo "Verified linux/amd64 and linux/arm64 manifests in ${image}"
+          done
 
       # Auto-deploy gate: the image build/push above always runs on a tag, but
       # deploying to the host runs ONLY when the repo/environment variable

--- a/.github/workflows/installer-platform-tests.yml
+++ b/.github/workflows/installer-platform-tests.yml
@@ -7,11 +7,21 @@ on:
     paths:
       - 'install.sh'
       - 'scripts/test-install.sh'
+      - 'docker-compose.yml'
+      - 'docker-compose.dev.yml'
+      - 'docker/nginx/default.conf'
+      - 'docker/nginx/bluegreen/default.conf'
+      - '.github/workflows/build_and_deploy.yml'
       - '.github/workflows/installer-platform-tests.yml'
   pull_request:
     paths:
       - 'install.sh'
       - 'scripts/test-install.sh'
+      - 'docker-compose.yml'
+      - 'docker-compose.dev.yml'
+      - 'docker/nginx/default.conf'
+      - 'docker/nginx/bluegreen/default.conf'
+      - '.github/workflows/build_and_deploy.yml'
       - '.github/workflows/installer-platform-tests.yml'
   workflow_dispatch:
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -110,7 +110,7 @@ services:
     networks:
       - devify_network
     healthcheck:
-      test: ["CMD", "mariadb-admin", "ping", "-h", "localhost", "--silent"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,7 +161,7 @@ services:
     networks:
       - devify_network
     healthcheck:
-      test: ["CMD", "mariadb-admin", "ping", "-h", "localhost", "--silent"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 5s
       retries: 10

--- a/docker/nginx/bluegreen/default.conf
+++ b/docker/nginx/bluegreen/default.conf
@@ -208,7 +208,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Block admin access on public HTTPS port (use dedicated admin port instead)
+    # Block current and legacy admin paths on the public HTTPS port
     location /admin {
         return 404;
     }
@@ -319,7 +319,7 @@ server {
 # =============================================================================
 # Admin Management Server (Restricted Access)
 # Port: 9443 (should be restricted by security group/firewall)
-# Entry URL: /devify-admin
+# Entry URL: /admin/
 # =============================================================================
 server {
     listen 9443 ssl;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -200,7 +200,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # Block admin access on public HTTPS port (use dedicated admin port instead)
+    # Block current and legacy admin paths on the public HTTPS port
     location /admin {
         return 404;
     }
@@ -311,7 +311,7 @@ server {
 # =============================================================================
 # Admin Management Server (Restricted Access)
 # Port: 9443 (should be restricted by security group/firewall)
-# Entry URL: /devify-admin
+# Entry URL: /admin/
 # =============================================================================
 server {
     listen 9443 ssl;

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ DEFAULT_ADMIN_PORT=19443
 DEFAULT_SMTP_PORT=25
 REGISTRY_GITHUB="registry.cn-beijing.aliyuncs.com/oneprolabs"
 REGISTRY_CN="registry.cn-beijing.aliyuncs.com/oneprolabs"
-INSTALLER_VERSION="0.2.0"
+INSTALLER_VERSION="0.2.1"
 HEALTH_TIMEOUT=120
 
 # Files fetched directly from the source repository tag (GitHub or Gitee).
@@ -1130,6 +1130,35 @@ docker_pull_progress() {
   return 0
 }
 
+verify_app_image_platform() {
+  local img="$1" manifest="" target_arch="${ARCH}"
+  case "${img}" in
+    */"${APP_NAME}":*|*/"${APP_NAME}-ui":*) ;;
+    *) return 0 ;;
+  esac
+
+  case "${DOCKER_DEFAULT_PLATFORM:-}" in
+    linux/amd64|linux/amd64/*) target_arch="amd64" ;;
+    linux/arm64|linux/arm64/*) target_arch="arm64" ;;
+  esac
+
+  if ! manifest="$(docker manifest inspect "${img}" 2>>"${LOG_FILE:-/dev/null}")"; then
+    log_warn "could not inspect the platform manifest for ${img}; continuing with normal pull retries"
+    return 0
+  fi
+  if ! printf '%s\n' "${manifest}" | awk -v arch="${target_arch}" '
+    /"architecture"[[:space:]]*:/ {
+      matches_arch = ($0 ~ "\\\"" arch "\\\"")
+    }
+    matches_arch && /"os"[[:space:]]*:[[:space:]]*"linux"/ {
+      found = 1
+    }
+    END { exit found ? 0 : 1 }
+  '; then
+    abort "${img} does not provide a linux/${target_arch} image; choose a multi-architecture release or run Devify on a supported host architecture"
+  fi
+}
+
 pull_images() {
   log_step "Pulling container images (registry: ${REGISTRY})"
   run_compose config --quiet || abort "invalid docker-compose configuration; see ${LOG_FILE}"
@@ -1145,6 +1174,7 @@ pull_images() {
     return 0
   fi
   for img in "${images[@]}"; do
+    verify_app_image_platform "${img}"
     attempt=1
     while :; do
       if pull_one "${img}"; then
@@ -1237,6 +1267,21 @@ health_check() {
     sleep 5
   done
   log_ok "Health check passed: ${url}"
+
+  local admin_deadline=$((SECONDS + HEALTH_TIMEOUT))
+  local admin_status=""
+  local admin_url="https://127.0.0.1:${ADMIN_PORT}/admin/"
+  until [[ "${admin_status}" == "200" || "${admin_status}" == "302" ]]; do
+    admin_status="$(curl --insecure --silent --show-error --output /dev/null \
+      --write-out '%{http_code}' --max-time 5 "${admin_url}" 2>/dev/null || true)"
+    if ((SECONDS >= admin_deadline)); then
+      abort "admin health check failed for ${admin_url} (last HTTP status: ${admin_status:-unavailable})"
+    fi
+    if [[ "${admin_status}" != "200" && "${admin_status}" != "302" ]]; then
+      sleep 5
+    fi
+  done
+  log_ok "Admin health check passed: ${admin_url} (HTTP ${admin_status})"
 }
 
 # ---------------------------------------------------------------------------
@@ -1286,7 +1331,7 @@ final_summary() {
   log_step "Installation complete"
   log_ok "Devify v${VERSION} installed at ${INSTALL_DIR}"
   log_info "URL:              ${SCHEME}://${DOMAIN}${PORT_SUFFIX}"
-  log_info "Admin panel:      https://${DOMAIN}:${ADMIN_PORT}/devify-admin (self-signed certificate)"
+  log_info "Admin panel:      https://${DOMAIN}:${ADMIN_PORT}/admin/ (self-signed certificate)"
   log_info "Username:         ${ADMIN_USERNAME}"
   log_info "Initial password: ${ADMIN_PASSWORD}"
   log_info "Install dir:      ${INSTALL_DIR}"

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -178,6 +178,123 @@ else
   ok "require_root skipped (root/sudo re-exec is host-specific, not run in CI)"
 fi
 
+section "final_summary"
+summary_out="$(
+  VERSION="test"
+  INSTALL_DIR="${TMPDIR:-/tmp}/devify-test-$$"
+  DATA_DIR="${INSTALL_DIR}/data"
+  SCHEME="https"
+  DOMAIN="192.0.2.1"
+  PORT_SUFFIX=":10443"
+  ADMIN_PORT="19443"
+  ADMIN_USERNAME="admin"
+  ADMIN_PASSWORD="test-password"
+  LOG_FILE=""
+  HTTPS="true"
+  final_summary
+)"
+expected_admin_url="https://192.0.2.1:19443/admin/"
+if printf '%s\n' "${summary_out}" | grep -Fq "Admin panel:      ${expected_admin_url}"; then
+  ok "final summary exposes the working admin panel URL"
+else
+  fail "final summary does not expose ${expected_admin_url}"
+fi
+if printf '%s\n' "${summary_out}" | grep -Fq "/devify-admin"; then
+  fail "final summary still exposes the obsolete /devify-admin path"
+else
+  ok "final summary omits the obsolete /devify-admin path"
+fi
+
+section "installer contracts"
+if [[ "${INSTALLER_VERSION}" == "0.2.1" ]]; then
+  ok "installer patch version is 0.2.1"
+else
+  fail "installer patch version is ${INSTALLER_VERSION}, expected 0.2.1"
+fi
+multiarch_builds="$(grep -Fc "platforms: linux/amd64,linux/arm64" .github/workflows/build_and_deploy.yml)"
+if [[ "${multiarch_builds}" == "2" ]]; then
+  ok "release workflow builds backend and UI for amd64 and arm64"
+else
+  fail "release workflow has ${multiarch_builds} multi-architecture build(s), expected 2"
+fi
+if grep -Fq "Verify published image platforms" .github/workflows/build_and_deploy.yml; then
+  ok "release workflow verifies published image platforms"
+else
+  fail "release workflow does not verify published image platforms"
+fi
+
+for compose_file in docker-compose.yml docker-compose.dev.yml; do
+  if grep -Fq 'test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]' "${compose_file}"; then
+    ok "${compose_file} uses MariaDB's authenticated health check"
+  else
+    fail "${compose_file} does not use MariaDB's authenticated health check"
+  fi
+done
+
+for nginx_file in docker/nginx/default.conf docker/nginx/bluegreen/default.conf; do
+  if grep -Fq "# Entry URL: /admin/" "${nginx_file}"; then
+    ok "${nginx_file} documents the working admin entry URL"
+  else
+    fail "${nginx_file} does not document the working admin entry URL"
+  fi
+done
+
+section "health_check"
+health_out_file="${TMPDIR:-/tmp}/devify-test-health-$$.log"
+curl() {
+  local last_arg="${!#}"
+  if [[ "${last_arg}" == "http://127.0.0.1:18001/health" ]]; then
+    return 0
+  fi
+  if [[ "${last_arg}" == "https://127.0.0.1:19443/admin/" ]]; then
+    printf '302'
+    return 0
+  fi
+  return 1
+}
+HTTP_PORT="18001"
+ADMIN_PORT="19443"
+HEALTH_TIMEOUT="1"
+health_check >"${health_out_file}" 2>&1
+unset -f curl
+if grep -Fq "Admin health check passed: https://127.0.0.1:19443/admin/ (HTTP 302)" "${health_out_file}"; then
+  ok "health check verifies the dedicated admin URL"
+else
+  fail "health check did not verify the dedicated admin URL: $(tr '\n' ' ' <"${health_out_file}")"
+fi
+rm -f "${health_out_file}"
+
+section "verify_app_image_platform"
+docker() {
+  printf '%s\n' '{"manifests":[{"platform":{"architecture":"amd64","os":"linux"}}]}'
+}
+APP_NAME="devify"
+ARCH="arm64"
+DOCKER_DEFAULT_PLATFORM=""
+LOG_FILE=""
+platform_out="$(verify_app_image_platform "registry.example/devify:1.3.0" 2>&1)"
+platform_rc=$?
+if [[ "${platform_rc}" == "1" ]] && printf '%s\n' "${platform_out}" | grep -Fq "does not provide a linux/arm64 image"; then
+  ok "unsupported application image architecture fails before pull retries"
+else
+  fail "unsupported application image architecture was not rejected: ${platform_out}"
+fi
+ARCH="amd64"
+if verify_app_image_platform "registry.example/devify-ui:1.3.0" >/dev/null 2>&1; then
+  ok "supported application image architecture passes manifest preflight"
+else
+  fail "supported application image architecture was rejected"
+fi
+ARCH="arm64"
+DOCKER_DEFAULT_PLATFORM="linux/amd64"
+if verify_app_image_platform "registry.example/devify:1.3.0" >/dev/null 2>&1; then
+  ok "explicit Docker target platform overrides the host architecture"
+else
+  fail "explicit Docker target platform was ignored"
+fi
+unset DOCKER_DEFAULT_PLATFORM
+unset -f docker
+
 section "run_compose (Windows path conversion)"
 if [[ "${PLATFORM}" == "windows" ]]; then
   COMPOSE_CMD=(echo)


### PR DESCRIPTION
## Summary
- publish and verify backend/UI images for linux/amd64 and linux/arm64
- fail fast on unsupported application image platforms while honoring DOCKER_DEFAULT_PLATFORM
- verify and print the working dedicated Admin URL at /admin/
- use MariaDB image-provided authenticated health checks in production and development Compose
- extend installer CI paths and smoke regression coverage

Closes #43

## Test plan
- [x] `bash scripts/test-install.sh`
- [x] `bash -n install.sh`
- [x] Parse both GitHub workflow YAML files
- [x] `docker compose config --quiet` for production and development Compose
- [x] Build backend Dockerfile for `linux/arm64`
- [x] Build UI Dockerfile for `linux/arm64`
- [x] Verify v1.3.0 ARM64 manifest failure is caught by installer preflight

## Notes
- Existing v1.3.0 images remain AMD64-only; the next tag build will publish the new multi-architecture images.