### PR TITLE
Import the settings task monitoring has been reading without

### DIFF
--- a/devify/threadline/tests/unit/test_task_monitoring.py
+++ b/devify/threadline/tests/unit/test_task_monitoring.py
@@ -1,0 +1,109 @@
+"""
+Unit tests for EmailTaskMonitor
+
+These exist because the module read settings.TASK_TIMEOUT_MINUTES without
+importing settings, and every method here catches Exception and returns
+{'error': ...} instead of raising. The NameError therefore never reached a
+caller: it became one log line, get_task_status_summary returned a payload
+with no health_status, and simple_health — the endpoint documented for load
+balancers — read the missing key as 'unknown' and answered 503 forever.
+
+So the assertion that matters in each test is 'error' not in result. A test
+that only checks the happy-path keys would pass on the degraded payload too.
+"""
+
+from datetime import timedelta
+
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from threadline.models import EmailTask
+from threadline.utils.monitoring import (
+    EmailTaskMonitor,
+    get_task_status_summary,
+)
+
+
+class EmailTaskMonitorTest(TestCase):
+    """Both metric paths must compute, not degrade into an error payload."""
+
+    def setUp(self):
+        # The module-level accessors cache for 60s and TestCase rolls back
+        # the database but not the cache, so a stale summary would otherwise
+        # leak between tests here.
+        cache.clear()
+        now = timezone.now()
+        EmailTask.objects.create(
+            task_type='IMAP_EMAIL_FETCH',
+            status=EmailTask.TaskStatus.COMPLETED,
+            started_at=now - timedelta(minutes=5),
+            completed_at=now - timedelta(minutes=4),
+        )
+        EmailTask.objects.create(
+            task_type='IMAP_EMAIL_FETCH',
+            status=EmailTask.TaskStatus.FAILED,
+        )
+        # Started long enough ago to land in the timeout branch, which is the
+        # code that reads TASK_TIMEOUT_MINUTES.
+        EmailTask.objects.create(
+            task_type='IMAP_EMAIL_FETCH',
+            status=EmailTask.TaskStatus.RUNNING,
+            started_at=now - timedelta(hours=6),
+        )
+
+    def test_get_task_metrics_computes(self):
+        metrics = EmailTaskMonitor.get_task_metrics()
+
+        self.assertNotIn('error', metrics, metrics.get('error'))
+        self.assertEqual(metrics['basic_counts']['total_tasks'], 3)
+        self.assertEqual(metrics['basic_counts']['completed_tasks'], 1)
+        self.assertEqual(metrics['basic_counts']['failed_tasks'], 1)
+        # Reached only if the timeout threshold was computed.
+        self.assertEqual(metrics['health_indicators']['timeout_tasks'], 1)
+
+    def test_get_task_status_summary_computes(self):
+        summary = get_task_status_summary()
+
+        self.assertNotIn('error', summary, summary.get('error'))
+        self.assertIn('health_status', summary)
+        self.assertEqual(summary['timeout_tasks_count'], 1)
+        # One running task over the threshold: warning, not healthy.
+        self.assertEqual(summary['health_status'], 'warning')
+
+    def test_status_summary_is_healthy_with_nothing_overdue(self):
+        EmailTask.objects.filter(
+            status=EmailTask.TaskStatus.RUNNING
+        ).update(started_at=timezone.now())
+
+        summary = get_task_status_summary()
+
+        self.assertNotIn('error', summary, summary.get('error'))
+        self.assertEqual(summary['timeout_tasks_count'], 0)
+        self.assertEqual(summary['health_status'], 'healthy')
+
+
+class SimpleHealthEndpointTest(TestCase):
+    """The load-balancer endpoint must answer 200 when nothing is overdue."""
+
+    def setUp(self):
+        cache.clear()
+
+    def test_simple_health_returns_200_when_healthy(self):
+        response = self.client.get(reverse('simple_health'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'healthy')
+
+    def test_simple_health_returns_503_when_a_task_is_overdue(self):
+        EmailTask.objects.create(
+            task_type='IMAP_EMAIL_FETCH',
+            status=EmailTask.TaskStatus.RUNNING,
+            started_at=timezone.now() - timedelta(hours=6),
+        )
+
+        response = self.client.get(reverse('simple_health'))
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'warning')

--- a/devify/threadline/utils/monitoring.py
+++ b/devify/threadline/utils/monitoring.py
@@ -7,6 +7,7 @@ Provides monitoring and metrics functionality for email tasks.
 import logging
 from datetime import timedelta
 from typing import Dict, List, Optional
+from django.conf import settings
 from django.utils import timezone
 from django.db.models import Count, Q, Avg
 from django.core.cache import cache


### PR DESCRIPTION
Closes #54.

`devify/threadline/utils/monitoring.py` reads `settings.TASK_TIMEOUT_MINUTES` in two methods and never imported `settings`. One line fixes it; the tests are the point of the PR.

## What was broken

```python
timeout_threshold = now - timedelta(minutes=settings.TASK_TIMEOUT_MINUTES)
```

`get_task_metrics()` line 54, `get_task_status_summary()` line 150. Both raise `NameError` there, so nothing below that line ever ran — timeout detection has never reported anything. The setting itself is fine: defined at `core/settings/email_system.py:109`, read correctly by `threadline/tasks/email_workflow.py`, `relay/tasks.py` and `expense/tasks/scan.py`.

## Why it survived

Every method here ends in `except Exception as exc: return {'error': str(exc)}`, so the `NameError` never reached a caller. It became a log line. Then:

```python
summary = get_task_status_summary()               # {'error': ...}
health_status = summary.get('health_status', 'unknown')   # 'unknown'
is_healthy = health_status == 'healthy'                    # False
status_code = 200 if is_healthy else 503                   # 503
```

`simple_health`'s own docstring calls it a "Simple health endpoint for load balancers", and it has been answering **503 unconditionally**. The container healthcheck is `curl -f http://127.0.0.1:8000/health`, a different route that does not touch this module, so the container stayed healthy and blue/green health-gating never saw it.

Nothing had been pointed at it — production nginx access logs show one hit on `/api/v1/health/` ever, my own `curl` during the v1.5.1 cutover, and zero on the other three routes; nothing in `ui/src` references them and none of the 21 enabled `PeriodicTask` rows reach this module. So the cost so far was not an outage, it was a trap set for whoever wired up the documented health endpoint.

## The tests

The assertion that matters is `'error' not in result`. A test checking only the happy-path keys passes on the degraded payload too, which is roughly how this went unnoticed since `b228e01` (2025-10-14).

Coverage: both metric paths, both health states of the endpoint, and the timeout branch specifically — the one that reads the setting.

They clear the cache in `setUp`: the module-level accessors wrap `get_cached_metrics` with a 60s timeout, and `TestCase` rolls back the database but not the cache, so a summary would otherwise leak between tests. That cost me two confusing failures before I spotted it.

## Verification

- 5 pass with the import; **removing the import again turns all 5 red**
- `pytest threadline/tests/unit` → 220 passed, 1 failed: `test_haraka_email_fetch_success`, which fails on `main` too

## Left alone

The `except Exception` → `{'error': ...}` pattern across all seven methods. Swallowing a `NameError` is what hid this for a year, and `simple_health` conflating "could not compute" with "unhealthy" is a real design flaw — but changing either touches every method and the endpoint's contract, and does not belong in a one-line import fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m