### PR TITLE
Check out only what the deploy host reads

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,28 +1,47 @@
 # Devify Deploy
 
-`devify-deploy` is the production entrypoint for the hosted Devify stack with
-the public homepage enabled.
+The production entrypoint for the hosted Devify stack with the public homepage
+enabled. It lives in the `devify` repository now; `devify-deploy` was merged in
+and archived.
 
-The application stack itself is maintained by the `devify` repository. This
-repository only keeps the homepage deployment delta, certificate helpers, and a
-single install/upgrade script.
+## What lives where on the deploy host
 
-## Repository Boundary
+Two checkouts of this one repository, at two different refs:
 
-- `devify`: API, worker, scheduler, UI, MySQL, Redis, Nginx app/API config, and
-  Haraka.
-- `devify-deploy`: `devify-home`, homepage Nginx config, production `.env`
-  sample, and deployment automation.
-- `.devify/`: generated local checkout of `devify`; not committed.
+- **the deploy root** — tracks `main`, and holds the runtime state the release
+  must not touch: `.env`, `data/`, `cache/`, `.active_color`,
+  `.rollback_version`. Only `deploy/` is checked out.
+- **`.devify/`** — pinned to the release tag, re-synced by every deploy. Only
+  `docker/` and `deploy/` are checked out, alongside the root files.
 
-## First Install
+Neither carries `devify/`, `ui/` or `home/`. Those build the images; the deploy
+host runs the images. `sync_devify` sets `.devify`'s sparse checkout itself, so
+it converges on its own — including narrowing a full checkout made before this
+was introduced.
+
+## First install
 
 ```bash
-git clone https://github.com/cloud2ai/devify-deploy.git
+git clone --filter=blob:none --sparse \
+    https://github.com/oneprolabs/devify.git devify-deploy
 cd devify-deploy
-cp env.sample .env
+git sparse-checkout set --cone deploy
+
+cp deploy/env.sample .env
 vim .env
 ./deploy/scripts/devify-deploy.sh install
+```
+
+`--cone` is passed explicitly because it is not the default for
+`sparse-checkout set` before git 2.37.
+
+### Narrowing an existing deploy root
+
+A deploy root cloned in full needs no re-clone — the runtime state stays put:
+
+```bash
+cd /path/to/deploy/root
+git sparse-checkout set --cone deploy
 ```
 
 The script will:

--- a/deploy/scripts/devify-deploy.sh
+++ b/deploy/scripts/devify-deploy.sh
@@ -33,6 +33,34 @@ DEVIFY_IMAGE_REPO="registry.cn-beijing.aliyuncs.com/oneprolabs/devify"
 DEVIFY_UI_IMAGE_REPO="registry.cn-beijing.aliyuncs.com/oneprolabs/devify-ui"
 DEVIFY_HOME_IMAGE_REPO="registry.cn-beijing.aliyuncs.com/oneprolabs/devify-home"
 
+# The deploy host runs images, not source. It needs the compose files, the
+# nginx/haraka/mysql config those files bind-mount, and this deploy tree —
+# not devify/, ui/ or home/, which exist only to build the images. Cone-mode
+# sparse checkout always keeps the root files, so the compose YAMLs come
+# along; these are the directories on top of them.
+CORE_SPARSE_DIRS="docker deploy"
+
+# Every path the deploy reads out of CORE_DIR: the files this script opens
+# and the bind-mount sources in the three compose files. Checked after each
+# sync so a wrong CORE_SPARSE_DIRS fails here, naming the file, instead of
+# somewhere later in a container that will not start.
+CORE_REQUIRED_PATHS="
+docker-compose.yml
+docker-compose.bluegreen.yml
+deploy/docker-compose.yml
+deploy/docker/nginx/aimychats.com.conf
+docker/nginx/default.conf
+docker/nginx/bluegreen/default.conf
+docker/nginx/bluegreen/active-upstream.conf.default
+docker/haraka/config/host_list.prod
+docker/haraka/config/plugins.prod
+docker/haraka/config/redis.ini
+docker/haraka/config/tls.ini
+docker/haraka/plugins/raw_email_saver.js
+docker/mysql/etc/my.cnf
+docker/mysql/initdb.d
+"
+
 # Single-flight lock so two mutating runs (a CI retry overlapping a manual run,
 # two operators) can't race on .active_color, the colored containers, or the
 # nginx switch. `set -o noclobber` makes creation atomic; after MAX_WAIT we take
@@ -128,10 +156,19 @@ sync_devify() {
     fi
     if [ ! -d "${CORE_DIR}/.git" ]; then
         rm -rf "${CORE_DIR}"
-        git clone "${DEVIFY_REPO}" "${CORE_DIR}"
+        # blob:none fetches file contents on demand; --sparse starts the
+        # working tree at the root files only.
+        git clone --filter=blob:none --sparse \
+            "${DEVIFY_REPO}" "${CORE_DIR}"
     else
         git -C "${CORE_DIR}" remote set-url origin "${DEVIFY_REPO}"
     fi
+
+    # Idempotent: narrows a full checkout made before this existed, and
+    # re-asserts the set afterwards. --cone is explicit because it is not
+    # the default for `set` before git 2.37.
+    # shellcheck disable=SC2086
+    git -C "${CORE_DIR}" sparse-checkout set --cone ${CORE_SPARSE_DIRS}
 
     git -C "${CORE_DIR}" fetch --tags --force origin
     if git -C "${CORE_DIR}" rev-parse --verify --quiet "origin/${DEVIFY_REF}" >/dev/null; then
@@ -139,6 +176,27 @@ sync_devify() {
     else
         git -C "${CORE_DIR}" checkout --force "${DEVIFY_REF}"
     fi
+
+    verify_core_files
+}
+
+# Guard the sparse set: a directory dropped from CORE_SPARSE_DIRS, or a new
+# bind mount added to a compose file without listing it here, would
+# otherwise surface as a container refusing to start on a bind-mount error.
+verify_core_files() {
+    local path missing=""
+    for path in ${CORE_REQUIRED_PATHS}; do
+        [ -e "${CORE_DIR}/${path}" ] || missing="${missing}    ${path}
+"
+    done
+    [ -z "${missing}" ] && return 0
+    die "The deploy checkout is missing files it needs:
+${missing}  Likely cause: CORE_SPARSE_DIRS (\"${CORE_SPARSE_DIRS}\") no longer covers
+    every path the compose files mount, or a mount was added without
+    listing it in CORE_REQUIRED_PATHS.
+  Try: add the directory to CORE_SPARSE_DIRS in this script, or run
+    git -C ${CORE_DIR} sparse-checkout disable
+    for a full checkout while you sort it out."
 }
 
 prepare_directories() {


### PR DESCRIPTION
The production deploy host carries **65MB of this repository, twice, to read 240KB of it**:

```
DEPLOY_ROOT (excluding data/)   65M
  .devify/       34M   ← full clone, pinned to the release tag
  .git/          12M
  devify/       9.0M   ← Django source
  home/         5.0M   ← VitePress source
  ui/           3.8M   ← frontend source
  deploy/       240K   ← what is actually used
```

Both checkouts currently sit on the same commit, so it is literally the same tree stored twice. `devify/`, `ui/` and `home/` exist to build the images; the host runs the images and never opens them.

Merging `devify-deploy` in caused half of this — the deploy root became a full checkout of this repository. The other half predates it: `sync_devify` has cloned `devify` in full since `0c15ca5`, when the split was introduced with the stated intent of keeping "only homepage-specific Compose and Nginx configuration locally". That intent held for the repository boundary and never reached the checkout.

Meanwhile `install.sh` has always done this correctly, with a curated `RELEASE_FILES` manifest and the comment *"Only what the deployed docker-compose.yml actually mounts/needs is included"*. Standalone took what it needed; blue/green took everything. This applies the same principle to blue/green.

## What changed

`sync_devify` clones with `--filter=blob:none --sparse` and sets the sparse checkout itself. That is idempotent — it **narrows a full checkout made before this existed** and re-asserts the set on every sync — so production converges with no manual step and no re-clone.

Cone mode always keeps root files, so the compose YAMLs come along and the set is just `docker/` and `deploy/`. `--cone` is explicit: it is not the default for `sparse-checkout set` before git 2.37, and production runs 2.34.1.

The deploy root's own narrowing is a README one-liner — `git sparse-checkout set --cone deploy` — no re-clone, so `.env`, `data/`, `.active_color` and `.rollback_version` stay exactly where they are.

## The guard

The failure mode here is silent until it isn't: drop a directory from the sparse set, or add a bind mount to a compose file without extending it, and the first symptom is a container refusing to start on a missing mount source, mid-deploy.

`CORE_REQUIRED_PATHS` lists all 14 paths the deploy actually opens — the files the script reads plus every bind-mount source across the three compose files — and `verify_core_files` checks them right after each sync, naming what is missing:

```
[devify-deploy] ERROR: The deploy checkout is missing files it needs:
    docker/nginx/default.conf
    docker/haraka/config/host_list.prod
    ...
  Likely cause: CORE_SPARSE_DIRS ("deploy") no longer covers every path the
    compose files mount, or a mount was added without listing it in
    CORE_REQUIRED_PATHS.
  Try: add the directory to CORE_SPARSE_DIRS in this script, or run
    git -C <core> sparse-checkout disable
    for a full checkout while you sort it out.
```

## Validation

- Sparse-cloned this tree with the exact commands `sync_devify` runs: all 14 required paths present; `devify/`, `ui/` and `home/` absent.
- Dropping `docker/` from the set makes the guard list all ten files it took away — the output above is that run.
- `scripts/test-install.sh` passes; `DEPLOY_ROOT` still derives to the repository root.

`--filter=blob:none` was ignored in the local test because a `file://` remote does not serve partial clones. Against GitHub it applies and `.git` shrinks further than the numbers here suggest.

## Rollout

Merging changes nothing by itself. The next release runs the new `sync_devify`, which narrows `.devify` in place. The deploy root's one-liner is a separate manual step, safe to run at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m