### PR TITLE
Enable cone mode before setting the sparse paths, not with the set

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -25,15 +25,18 @@ was introduced.
 git clone --filter=blob:none --sparse \
     https://github.com/oneprolabs/devify.git devify-deploy
 cd devify-deploy
-git sparse-checkout set --cone deploy
+git sparse-checkout init --cone
+git sparse-checkout set deploy
 
 cp deploy/env.sample .env
 vim .env
 ./deploy/scripts/devify-deploy.sh install
 ```
 
-`--cone` is passed explicitly because it is not the default for
-`sparse-checkout set` before git 2.37.
+`init --cone` comes first because git only learned `--cone` on
+`sparse-checkout set` in 2.36. Before that — production runs 2.34 — the flag
+is taken as a literal path pattern, which lands the checkout in non-cone mode
+and deletes the root files, `docker-compose.yml` included.
 
 ### Narrowing an existing deploy root
 
@@ -41,7 +44,8 @@ A deploy root cloned in full needs no re-clone — the runtime state stays put:
 
 ```bash
 cd /path/to/deploy/root
-git sparse-checkout set --cone deploy
+git sparse-checkout init --cone
+git sparse-checkout set deploy
 ```
 
 The script will:

--- a/deploy/scripts/devify-deploy.sh
+++ b/deploy/scripts/devify-deploy.sh
@@ -165,10 +165,30 @@ sync_devify() {
     fi
 
     # Idempotent: narrows a full checkout made before this existed, and
-    # re-asserts the set afterwards. --cone is explicit because it is not
-    # the default for `set` before git 2.37.
+    # re-asserts the set afterwards.
+    #
+    # `init --cone` before `set`, not `set --cone`: git only learned the
+    # --cone flag on `set` in 2.36, and production runs 2.34, where it is
+    # silently taken as a literal path pattern. That lands in non-cone
+    # mode, where a bare "docker" matches any directory of that name at any
+    # depth — ui/docker and home/docker survive — while the root files
+    # match nothing and get removed, taking docker-compose.yml with them.
+    git -C "${CORE_DIR}" sparse-checkout init --cone
     # shellcheck disable=SC2086
-    git -C "${CORE_DIR}" sparse-checkout set --cone ${CORE_SPARSE_DIRS}
+    git -C "${CORE_DIR}" sparse-checkout set ${CORE_SPARSE_DIRS}
+    # Assert the mode rather than trust it. Without this, a git that took
+    # --cone as a pattern fails later in verify_core_files, which blames
+    # CORE_SPARSE_DIRS for a checkout that is simply in the wrong mode.
+    if [ "$(git -C "${CORE_DIR}" config core.sparseCheckoutCone)" != "true" ]; then
+        die "Sparse checkout of ${CORE_DIR} is not in cone mode.
+  Likely cause: this git ($(git --version)) did not accept \`sparse-checkout
+    init --cone\`. Outside cone mode the entries are gitignore patterns, so
+    \"docker\" matches any directory of that name at any depth and the root
+    files match nothing at all — docker-compose.yml would be deleted.
+  Try: upgrade git to 2.25 or newer, or run
+    git -C ${CORE_DIR} sparse-checkout disable
+    to fall back to a full checkout."
+    fi
 
     git -C "${CORE_DIR}" fetch --tags --force origin
     if git -C "${CORE_DIR}" rev-parse --verify --quiet "origin/${DEVIFY_REF}" >/dev/null; then


### PR DESCRIPTION
Follow-up to #56, which shipped `git sparse-checkout set --cone`. That flag only exists on `set` from git **2.36**. Production runs **2.34.1**, where it is silently taken as a literal path pattern.

## What that does

The checkout lands in gitignore-pattern mode with three patterns — `--cone`, `docker`, `deploy`:

```
$ git sparse-checkout list
--cone
docker
deploy
$ git config core.sparseCheckoutCone
                    # unset
```

In pattern mode a bare `docker` matches a directory of that name at **any depth**, so `ui/docker` and `home/docker` survived while the rest of those trees went. And the root files match no pattern at all, so they were deleted:

```
$ ls .devify
data deploy docker home ui        # no docker-compose.yml
```

The next deploy would have failed on a missing compose file. `init --cone` then `set` is valid on every version since 2.25.

## Why the local check missed it

This machine runs git 2.43, where `set --cone` is correct. The sparse clone I verified in #56 was a real verification against the wrong git version — it proved the path set was right and proved nothing about the invocation. Reproducing it locally is not possible without a 2.34 to test against; the production run is the evidence, quoted above.

## The guard was right, its message was not

`verify_core_files` did its job — it lists `docker-compose.yml` as missing. But its message blames `CORE_SPARSE_DIRS` for not covering the paths, when the paths are fine and the *mode* is wrong. So the mode is now asserted directly, right after it is set, and says what actually happened:

```
[devify-deploy] ERROR: Sparse checkout of <core> is not in cone mode.
  Likely cause: this git (git version 2.34.1) did not accept `sparse-checkout
    init --cone`. Outside cone mode the entries are gitignore patterns, so
    "docker" matches any directory of that name at any depth and the root
    files match nothing at all — docker-compose.yml would be deleted.
  Try: upgrade git to 2.25 or newer, or run
    git -C <core> sparse-checkout disable
    to fall back to a full checkout.
```

## Production

Already repaired by hand, on the corrected config:

| | before | after |
|---|---|---|
| `.devify` | 35M | **17M** |
| deploy root | 31M | **13M** |

All 14 paths in `CORE_REQUIRED_PATHS` present, `devify/` `ui/` `home/` gone, and `.env`, `data/`, `cache/`, `.active_color`, `.rollback_version` untouched.

Note that #56's sparse code has still never run on production — see #58: the orchestrator self-updates on disk but the running process keeps the functions it parsed at startup, so a change to `devify-deploy.sh` first takes effect on the release *after* the one that ships it. This PR will be in place before that happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m
