### PR TITLE
Read the platform from the verbose manifest so installs work again

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1142,7 +1142,14 @@ verify_app_image_platform() {
     linux/arm64|linux/arm64/*) target_arch="arm64" ;;
   esac
 
-  if ! manifest="$(docker manifest inspect "${img}" 2>>"${LOG_FILE:-/dev/null}")"; then
+  # --verbose, not the plain form. A single-platform release is pushed as
+  # a bare image manifest, which carries no architecture or os of its own —
+  # those live in the config blob — so the plain output has nothing for the
+  # scan below to match and every install aborted claiming the image had no
+  # linux image for this host. Every release since arm64 was dropped is
+  # single-platform. --verbose reports a platform block for both shapes.
+  if ! manifest="$(docker manifest inspect --verbose "${img}" \
+      2>>"${LOG_FILE:-/dev/null}")"; then
     log_warn "could not inspect the platform manifest for ${img}; continuing with normal pull retries"
     return 0
   fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -320,6 +320,50 @@ fi
 unset DOCKER_DEFAULT_PLATFORM
 unset -f docker
 
+# The fixture above is a manifest list, which is why these checks stayed
+# green while every install aborted: since arm64 was dropped, releases are
+# pushed as a bare image manifest that carries no architecture at all. This
+# stub answers with the real shapes — the plain form has nothing to match,
+# the --verbose form reports the platform — so a regression to the plain
+# form fails here instead of in front of whoever is installing.
+docker() {
+  local arg verbose=0
+  for arg in "$@"; do
+    [[ "${arg}" == "--verbose" ]] && verbose=1
+  done
+  if [[ "${verbose}" == "1" ]]; then
+    printf '%s\n' '{"Ref":"registry.example/devify:1.5.3","Descriptor":{"mediaType":"application/vnd.oci.image.manifest.v1+json","platform":{"architecture":"amd64","os":"linux"}}}'
+  else
+    printf '%s\n' '{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"digest":"sha256:abc"},"layers":[{"digest":"sha256:def"}]}'
+  fi
+}
+APP_NAME="devify"
+ARCH="amd64"
+DOCKER_DEFAULT_PLATFORM=""
+LOG_FILE=""
+# Command substitution, not a direct call: verify_app_image_platform ends
+# in abort, which exits, and a direct call would take this whole suite with
+# it instead of reporting a failure.
+single_out="$(verify_app_image_platform "registry.example/devify:1.5.3" 2>&1)"
+single_rc=$?
+if [[ "${single_rc}" == "0" ]]; then
+  ok "single-platform release passes the manifest preflight"
+else
+  fail "single-platform release was rejected, so the preflight is not reading --verbose: ${single_out}"
+fi
+ARCH="arm64"
+single_out="$(verify_app_image_platform "registry.example/devify:1.5.3" 2>&1)"
+single_rc=$?
+if [[ "${single_rc}" == "1" ]] && printf '%s\n' "${single_out}" \
+    | grep -Fq "does not provide a linux/arm64 image"; then
+  ok "single-platform release is still rejected for the wrong architecture"
+else
+  fail "single-platform release was accepted for arm64: ${single_out}"
+fi
+ARCH="amd64"
+unset DOCKER_DEFAULT_PLATFORM
+unset -f docker
+
 section "run_compose (Windows path conversion)"
 if [[ "${PLATFORM}" == "windows" ]]; then
   COMPOSE_CMD=(echo)


### PR DESCRIPTION
**The one-click installer has been broken since arm64 was dropped.** Every release after v1.5.0 — 1.5.1, 1.5.2, 1.5.3 — aborts before pulling anything:

```
ERROR: registry.cn-beijing.aliyuncs.com/oneprolabs/devify:1.5.3 does not
provide a linux/amd64 image; choose a multi-architecture release or run
Devify on a supported host architecture
```

The image *is* amd64. The message is wrong in the most misleading way available.

## Why

`verify_app_image_platform` scans `docker manifest inspect` for an `"architecture"` line followed by `"os": "linux"`. A single-platform release is pushed as a bare image manifest, which carries neither — they live in the config blob:

```console
$ docker manifest inspect .../devify:1.5.3 | grep -c '"architecture"'
0
$ docker manifest inspect .../devify:1.5.3 | grep -c '"os"'
0
```

So the scan matches nothing, `found` stays 0, and `abort` fires. v1.5.0 predates the arm cut, which is why this only starts at 1.5.1.

This is the same root cause as the release workflow's platform verification, in a second place. Both were written against manifest lists, and dropping arm64 stopped producing them.

## The fix

`docker manifest inspect --verbose` reports a platform block for both shapes — under `Descriptor` for a lone manifest, under each `manifests[]` entry for a list. The existing awk already reads that structure, so only the invocation changes.

Verified against the published images:

| image | asked for | result |
|---|---|---|
| `devify:1.5.3` (single-platform) | amd64 | passes |
| `devify:1.5.3` | arm64 | **still rejected** |
| `devify:1.4.1` (multi-platform) | amd64 | passes |
| `devify:1.4.1` | arm64 | passes |

The guard is not weakened — a genuinely unsupported architecture is still refused.

## Why the tests were green

`scripts/test-install.sh` stubbed `docker` with a manifest-list fixture:

```bash
docker() {
  printf '%s\n' '{"manifests":[{"platform":{"architecture":"amd64","os":"linux"}}]}'
}
```

A shape the release has not produced since arm64 went. The tests were checking the installer against a world that no longer exists.

The new stub returns the real plain and verbose outputs and switches on the flag, so removing `--verbose` fails here:

```
FAIL: single-platform release was rejected, so the preflight is not reading
--verbose: ERROR: registry.example/devify:1.5.3 does not provide a
linux/amd64 image; ...
```

It also calls through command substitution. `verify_app_image_platform` ends in `abort`, which exits — my first attempt called it directly and silently took the whole suite down mid-run instead of reporting a failure.

## Worth a follow-up

Two places have now been found asserting image platforms against a manifest shape the release stopped producing, and both were found in production rather than in CI. A post-release smoke test that actually runs `install.sh` against the tag it just published would have caught both on the first release after the arm cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m