### PR TITLE
Default images to their public paths, and let China override them

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,7 +10,7 @@ x-logging: &default-logging
 
 services:
   devify-home:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify-home:${DEVIFY_IMAGE_TAG:-latest}
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify-home:${DEVIFY_IMAGE_TAG:-latest}
     container_name: devify-home
     restart: unless-stopped
     logging: *default-logging

--- a/deploy/env.sample
+++ b/deploy/env.sample
@@ -174,3 +174,18 @@ VITE_API_BASE_URL=https://app.aimychats.com
 # ============================================================================
 # HTTP_PROXY=http://proxy.example.com:8080
 # HTTPS_PROXY=http://proxy.example.com:8080
+
+# ============================================================================
+# Image registry
+# ============================================================================
+# Images default to their public paths: docker.io/oneprolabs for ours, the
+# upstream project for each middleware image. Only the ACR namespace carries
+# copies of the middleware, so a China deployment overrides all five — the
+# prefix alone is not enough, because the two registries do not shape those
+# paths the same way. install.sh writes these for the cn channel.
+#
+# DEVIFY_REGISTRY=registry.cn-beijing.aliyuncs.com/oneprolabs
+# DEVIFY_NGINX_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/nginx:latest
+# DEVIFY_MYSQL_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/mariadb:11.6
+# DEVIFY_REDIS_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/redis:alpine
+# DEVIFY_HARAKA_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/haraka:latest

--- a/docker-compose.bluegreen.yml
+++ b/docker-compose.bluegreen.yml
@@ -37,7 +37,7 @@ services:
     extends:
       file: docker-compose.yml
       service: devify-api
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify:${DEVIFY_IMAGE_TAG:-latest}
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:${DEVIFY_IMAGE_TAG:-latest}
     container_name: devify-api-blue
     profiles: ["blue"]
     depends_on:
@@ -48,7 +48,7 @@ services:
     extends:
       file: docker-compose.yml
       service: devify-api
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify:${DEVIFY_IMAGE_TAG:-latest}
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:${DEVIFY_IMAGE_TAG:-latest}
     container_name: devify-api-green
     profiles: ["green"]
     depends_on:
@@ -59,7 +59,7 @@ services:
     extends:
       file: docker-compose.yml
       service: devify-ui
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify-ui:${DEVIFY_IMAGE_TAG:-latest}
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify-ui:${DEVIFY_IMAGE_TAG:-latest}
     container_name: devify-ui-blue
     profiles: ["blue"]
 
@@ -67,7 +67,7 @@ services:
     extends:
       file: docker-compose.yml
       service: devify-ui
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify-ui:${DEVIFY_IMAGE_TAG:-latest}
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify-ui:${DEVIFY_IMAGE_TAG:-latest}
     container_name: devify-ui-green
     profiles: ["green"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ x-logging: &default-logging
 
 services:
   devify-api:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify:latest
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:latest
     container_name: devify-api
     restart: unless-stopped
     logging: *default-logging
@@ -47,7 +47,7 @@ services:
       start_period: 60s
 
   devify-worker:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify:latest
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:latest
     container_name: devify-worker
     restart: unless-stopped
     stop_grace_period: 60s
@@ -72,7 +72,7 @@ services:
     command: celery
 
   devify-scheduler:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify:latest
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:latest
     container_name: devify-scheduler
     restart: unless-stopped
     stop_grace_period: 30s
@@ -93,7 +93,7 @@ services:
     command: celery-beat
 
   devify-ui:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/devify-ui:latest
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify-ui:latest
     build:
       context: ./ui
       dockerfile: Dockerfile
@@ -118,7 +118,7 @@ services:
 
   # Recommend to use nginx proxy manager to manage the outside access
   nginx:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/nginx:latest
+    image: ${DEVIFY_NGINX_IMAGE:-nginx:latest}
     container_name: devify-nginx
     restart: unless-stopped
     logging: *default-logging
@@ -147,7 +147,7 @@ services:
       start_period: 30s
 
   mysql:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/mariadb:11.6
+    image: ${DEVIFY_MYSQL_IMAGE:-mariadb:11.6}
     container_name: devify-mariadb
     restart: unless-stopped
     logging: *default-logging
@@ -168,7 +168,7 @@ services:
       start_period: 30s
 
   redis:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/redis:alpine
+    image: ${DEVIFY_REDIS_IMAGE:-redis:alpine}
     container_name: devify-redis
     restart: unless-stopped
     logging: *default-logging
@@ -186,7 +186,7 @@ services:
       start_period: 10s
 
   haraka:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/haraka:latest
+    image: ${DEVIFY_HARAKA_IMAGE:-instrumentisto/haraka:latest}
     container_name: devify-haraka
     restart: unless-stopped
     logging: *default-logging

--- a/env.sample
+++ b/env.sample
@@ -214,3 +214,18 @@ VITE_API_BASE_URL=http://localhost:8000
 # VITE_SENTRY_RELEASE=1.0.0
 # VITE_SENTRY_TRACES_SAMPLE_RATE=0.1
 # VITE_SENTRY_SEND_PII=false
+
+# ============================================================================
+# Image registry
+# ============================================================================
+# Images default to their public paths: docker.io/oneprolabs for ours, the
+# upstream project for each middleware image. Only the ACR namespace carries
+# copies of the middleware, so a China deployment overrides all five — the
+# prefix alone is not enough, because the two registries do not shape those
+# paths the same way. install.sh writes these for the cn channel.
+#
+# DEVIFY_REGISTRY=registry.cn-beijing.aliyuncs.com/oneprolabs
+# DEVIFY_NGINX_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/nginx:latest
+# DEVIFY_MYSQL_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/mariadb:11.6
+# DEVIFY_REDIS_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/redis:alpine
+# DEVIFY_HARAKA_IMAGE=registry.cn-beijing.aliyuncs.com/oneprolabs/haraka:latest

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,11 @@ DEFAULT_HTTP_PORT=8080
 DEFAULT_HTTPS_PORT=10443
 DEFAULT_ADMIN_PORT=19443
 DEFAULT_SMTP_PORT=25
-REGISTRY_GITHUB="registry.cn-beijing.aliyuncs.com/oneprolabs"
+# Our own images live under the same namespace in both registries, so the
+# channel only swaps the prefix. The middleware images do not: Docker Hub
+# serves them from their own upstream paths, and only the ACR namespace
+# carries copies of them. See registry_channel_env below.
+REGISTRY_GITHUB="docker.io/oneprolabs"
 REGISTRY_CN="registry.cn-beijing.aliyuncs.com/oneprolabs"
 INSTALLER_VERSION="0.2.1"
 HEALTH_TIMEOUT=120
@@ -878,6 +882,23 @@ ensure_env_key() {
   fi
 }
 
+# Compose defaults every image to its public path — docker.io/oneprolabs for
+# ours, the upstream project for each middleware image. The cn channel points
+# them all at the ACR namespace, which is the only one carrying copies of the
+# middleware. Written as .env keys rather than patched into the compose file
+# so the reference stays readable and a reinstall can see what it chose.
+registry_channel_env() {
+  local env_file="${INSTALL_DIR}/.env"
+  [[ -f "${env_file}" ]] || return 0
+  ensure_env_key "${env_file}" "DEVIFY_REGISTRY" "${REGISTRY}"
+  if [[ "${CHANNEL}" == "cn" ]]; then
+    ensure_env_key "${env_file}" "DEVIFY_NGINX_IMAGE"  "${REGISTRY_CN}/nginx:latest"
+    ensure_env_key "${env_file}" "DEVIFY_MYSQL_IMAGE"  "${REGISTRY_CN}/mariadb:11.6"
+    ensure_env_key "${env_file}" "DEVIFY_REDIS_IMAGE"  "${REGISTRY_CN}/redis:alpine"
+    ensure_env_key "${env_file}" "DEVIFY_HARAKA_IMAGE" "${REGISTRY_CN}/haraka:latest"
+  fi
+}
+
 generate_env() {
   log_step "Generating configuration"
   local env_file="${INSTALL_DIR}/.env"
@@ -996,8 +1017,9 @@ patch_compose() {
   local haraka_ini="${INSTALL_DIR}/docker/haraka/config/redis.ini"
   local host_list="${INSTALL_DIR}/docker/haraka/config/host_list.prod"
 
-  # registry: cn ACR image refs -> channel registry
-  sed_inplace "${compose}" -E "s|(image:[[:space:]]*)registry\.cn-beijing\.aliyuncs\.com/oneprolabs/(${APP_NAME}(-ui)?)|\1${REGISTRY}/\2|g"
+  # The registry is no longer rewritten here: compose interpolates
+  # DEVIFY_REGISTRY and the four middleware image variables from .env, which
+  # registry_channel_env writes. Only the tag pin below is still textual.
   # pin version-consistent image tags
   sed_inplace "${compose}" -E "s|(image:[[:space:]]*[^ ]+/${APP_NAME}(-ui)?):latest|\1:${IMAGE_TAG}|g"
   # redis authentication
@@ -1431,6 +1453,7 @@ main() {
   fi
   fetch_release_files
   generate_env
+  registry_channel_env
   patch_compose
   generate_certs
   pull_images

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -238,6 +238,22 @@ elif [[ -x "${deploy_script#./}" ]]; then
 else
   fail "release workflow invokes ${deploy_script}, which is missing or not executable"
 fi
+# Every image reference must stay interpolable. A hardcoded registry in a
+# compose file cannot be redirected by channel, and that is how the four
+# middleware images ended up pinned to ACR for every install, including the
+# ones that had chosen the github channel.
+hardcoded_registry=0
+for compose_file in docker-compose.yml docker-compose.bluegreen.yml \
+    deploy/docker-compose.yml; do
+  if grep -E "^[[:space:]]*image:[[:space:]]*registry\." "${compose_file}" \
+      >/dev/null 2>&1; then
+    fail "${compose_file} hardcodes a registry in an image reference"
+    hardcoded_registry=1
+  fi
+done
+if [[ "${hardcoded_registry}" == "0" ]]; then
+  ok "compose files leave every image reference interpolable"
+fi
 if grep -Fq "Verify published image platforms" .github/workflows/build_and_deploy.yml; then
   ok "release workflow verifies published image platforms"
 else


### PR DESCRIPTION
Every image in every compose file was pinned to the Aliyun ACR namespace, so an install outside China pulled all of it from a China registry.

`install.sh` could not help. `patch_compose` rewrote only `devify` and `devify-ui`:

```bash
sed_inplace "${compose}" -E "s|...oneprolabs/(${APP_NAME}(-ui)?)|\1${REGISTRY}/\2|g"
```

`nginx`, `mariadb`, `redis` and `haraka` matched nothing and stayed on ACR whichever channel was chosen. And `REGISTRY_GITHUB` was itself the ACR address, so even the app images came back to China on the `github` channel — the channel existed but changed nothing.

## Two classes of image, two mechanisms

They are not symmetric, which is the whole reason one variable does not do it.

**Ours** keep their name and only change prefix, so one variable covers all three:

```yaml
image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:${DEVIFY_IMAGE_TAG:-latest}
```

**Middleware** has no counterpart under `docker.io/oneprolabs` — Docker Hub serves each from its own upstream path — so each takes a full reference:

| service | default | cn override |
|---|---|---|
| nginx | `nginx:latest` | `…/oneprolabs/nginx:latest` |
| mysql | `mariadb:11.6` | `…/oneprolabs/mariadb:11.6` |
| redis | `redis:alpine` | `…/oneprolabs/redis:alpine` |
| haraka | `instrumentisto/haraka:latest` | `…/oneprolabs/haraka:latest` |

`haraka` has no unprefixed form — `docker.io/library/haraka` does not exist. `instrumentisto/haraka` is the upstream our ACR copy is built from; its `org.opencontainers.image.source` label points there.

`registry_channel_env` writes the five keys into `.env` for the `cn` channel; the `github` channel writes none and takes the defaults. That replaces the registry `sed`, which now has nothing to match.

## Verified through compose, not by reading

```
default channel                     cn channel
─────────────────────────           ─────────────────────────
docker.io/oneprolabs/devify         …/oneprolabs/devify
docker.io/oneprolabs/devify-ui      …/oneprolabs/devify-ui
nginx:latest                        …/oneprolabs/nginx:latest
mariadb:11.6                        …/oneprolabs/mariadb:11.6
redis:alpine                        …/oneprolabs/redis:alpine
instrumentisto/haraka:latest        …/oneprolabs/haraka:latest
```

The blue/green stack layered over all three compose files resolves to exactly the six ACR references it runs today, so **production is unchanged** once those keys are in its `.env`. That is a deploy-time step, not part of this merge.

Availability checked from the production host: `nginx:alpine`, `mariadb:11.6`, `redis:alpine` and `instrumentisto/haraka` all pull; bare `haraka` and the Aliyun `library/` namespace do not.

## Contract test

A hardcoded registry cannot be redirected by channel, which is exactly how the middleware ended up pinned. The suite now fails if any compose file reintroduces one:

```
FAIL: docker-compose.yml hardcodes a registry in an image reference
```

## Follow-up, not in scope here

Re-hosting freezes an image at the moment it was copied. `oneprolabs/mariadb:11.6` was built **2024-11-21** — production has been missing roughly ten months of MariaDB patch releases, and 11.6 is a short-term release whose support window is worth checking. Moving the cn channel onto fresher copies, or onto upstream with a daemon-level registry mirror, is a separate change with a real database migration to think about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m