### PR TITLE
Hand the deploy over to the orchestrator it just pulled

### DIFF
--- a/deploy/scripts/devify-deploy.sh
+++ b/deploy/scripts/devify-deploy.sh
@@ -12,6 +12,10 @@ if [ ! -f "${DEPLOY_ROOT}/deploy/scripts/devify-deploy.sh" ]; then
     echo "  Try: run it in place, as <checkout>/deploy/scripts/devify-deploy.sh" >&2
     exit 1
 fi
+# Captured at file scope, where "$@" is still the script's own arguments,
+# so self_update can hand them to the replacement process.
+DEVIFY_ARGV=("$@")
+
 CORE_DIR="${DEPLOY_ROOT}/.devify"
 ENV_FILE="${DEPLOY_ROOT}/.env"
 # The blue/green sample, not the repository-root one: that is the
@@ -408,16 +412,46 @@ install_stack() {
     bluegreen_deploy
 }
 
-upgrade_stack() {
-    acquire_deploy_lock
-    check_requirements
-    ensure_env
-    # Refresh this script from main. The overlay and nginx configs no
-    # longer live here — they come from CORE_DIR at the pinned tag — so
-    # this now updates the orchestrator alone.
-    if [ "${LOCAL_MODE}" != "1" ]; then
-        git -C "${DEPLOY_ROOT}" pull --ff-only origin main || true
+# Refresh this script from main, then hand over to the version that was
+# pulled. Bash defines every function while reading down to the `main` call
+# at the bottom of the file, so a running deploy keeps the functions it
+# parsed at startup: without the exec, a change to this script is skipped by
+# the release that ships it and first runs on the one after. That is not
+# only surprising — it means a release can run an old orchestrator against
+# the new tag's compose files, with nothing to say so.
+#
+# Called before acquire_deploy_lock on purpose. exec does not fire EXIT
+# traps, so exec-ing while holding the lock would leave it behind for the
+# replacement process to wait out.
+self_update() {
+    [ "${LOCAL_MODE}" = "1" ] && return 0
+    [ -n "${DEVIFY_SELF_UPDATED:-}" ] && return 0
+
+    local before after
+    before="$(git -C "${DEPLOY_ROOT}" rev-parse HEAD 2>/dev/null || true)"
+    if ! git -C "${DEPLOY_ROOT}" pull --ff-only origin main; then
+        log "WARNING: could not refresh the orchestrator from main.
+  Likely cause: the deploy host cannot reach the git remote right now, or
+    ${DEPLOY_ROOT} has local commits that are not a fast-forward.
+  Effect: this deploy runs the orchestrator already on disk, which may be
+    older than the tag being deployed.
+  Try: git -C ${DEPLOY_ROOT} pull --ff-only origin main, by hand."
+        return 0
     fi
+    after="$(git -C "${DEPLOY_ROOT}" rev-parse HEAD 2>/dev/null || true)"
+    [ "${before}" = "${after}" ] && return 0
+
+    log "Orchestrator updated ${before:0:7} -> ${after:0:7}; restarting with it"
+    export DEVIFY_SELF_UPDATED=1
+    exec "${DEPLOY_ROOT}/deploy/scripts/devify-deploy.sh" \
+        ${DEVIFY_ARGV[@]+"${DEVIFY_ARGV[@]}"}
+}
+
+upgrade_stack() {
+    check_requirements
+    self_update
+    acquire_deploy_lock
+    ensure_env
     sync_devify
     bluegreen_deploy
 }


### PR DESCRIPTION
Closes #58. Option 2 from the issue.

## The problem

Bash defines every function while reading down to the `main` call at the bottom of the 622-line script, so a running deploy keeps the functions it parsed at startup. `upgrade_stack` pulled the script on disk and then carried on with the old one:

```bash
git -C "${DEPLOY_ROOT}" pull --ff-only origin main || true   # replaces the file
sync_devify                                                  # still the old function
```

A change to this script was therefore skipped by the release that shipped it, and first ran on the one after.

**v1.5.3 is the demonstration.** It shipped the sparse checkout, the release succeeded, the file on disk was updated to `a6e1f50` — and `.devify` did not narrow at all, 34M → 35M, because `sync_devify` was still the previous one. Nothing reported this.

It never bit before because releases change what the orchestrator *reads* — compose files, nginx config, all of it inside `.devify`, re-synced and read fresh every run. #56 was the first to change how the orchestrator itself *behaves*.

## Why the surprise is the smaller half

A release can run an **old orchestrator against the new tag's compose files**. Today that is benign. A change touching both — a new service, a new mount, a different switch order — would run one half against the other, silently.

**v1.5.4 came close.** Its `git pull` timed out after 131s, `|| true` swallowed it without a line of output, and the orchestrator that ran was the one still carrying the `set --cone` bug from #56. It re-added `--cone` to the sparse config. It did no damage only because cone mode had already been repaired by hand — otherwise it would have deleted `docker-compose.yml` again and broken the next release.

## The change

`self_update` pulls, and if HEAD moved, `exec`s the pulled script with the original arguments. `DEVIFY_SELF_UPDATED` bounds it to a single hand-over.

Two details that are not obvious:

- **`DEVIFY_ARGV` is captured at file scope**, where `"$@"` is still the script's own arguments — inside `upgrade_stack` it would be the function's.
- **It runs before `acquire_deploy_lock`.** `exec` does not fire `EXIT` traps, so exec-ing while holding the lock would leave the lock file behind for the replacement process to wait 300s on and then declare stale.

The pull no longer fails silently either. `|| true` is exactly why v1.5.4's timeout left no trace; a failure now says what it means for the deploy that is about to continue on older code.

## Verified against a real git remote

Not reasoned about — built a bare remote and a working checkout and ran all four paths:

| scenario | result |
|---|---|
| orchestrator updated | hands over once, runs the new code, `[upgrade --some-flag]` intact |
| no update | no re-exec |
| `--local` | skipped entirely |
| remote unreachable | warns, continues on what is on disk |

## Rollout

Because of the very bug it fixes, **this lands one release late**: the next release runs the current orchestrator, which pulls this one and — not having the exec yet — carries on without it. The release after that hands over. Nothing to do about that from here; production's checkout can also just be pulled by hand once, which is what I have been doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m