### PR TITLE
Roll the workers back with the API, not just the colored services

### DIFF
--- a/deploy/scripts/devify-deploy.sh
+++ b/deploy/scripts/devify-deploy.sh
@@ -491,6 +491,14 @@ rollback_stack() {
     fi
     switch_traffic "${active}" "${target}"
     echo "${target}" > "${DEPLOY_ROOT}/.active_color"
+
+    # The colored services are only half the deploy. Without this the API
+    # returns to ${rbtag} and the workers keep running the version being
+    # rolled away from, against the same database. DEVIFY_IMAGE_TAG is
+    # already exported above, so this recreates them at ${rbtag} too.
+    log "Rolling devify-worker / devify-scheduler back to ${rbtag}..."
+    compose up -d devify-worker devify-scheduler
+
     log "Rolled back: active color is now ${target}. ${active} left running for inspection."
 }
 

--- a/docker-compose.bluegreen.yml
+++ b/docker-compose.bluegreen.yml
@@ -71,7 +71,12 @@ services:
     container_name: devify-ui-green
     profiles: ["green"]
 
+  # Pinned like the colored services. The base file leaves these on :latest,
+  # which meant a deploy moved them by whatever :latest happened to be and a
+  # rollback could not move them back at all — the API would return to the
+  # previous version while the workers stayed on the new code.
   devify-worker:
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:${DEVIFY_IMAGE_TAG:-latest}
     depends_on: !override
       mysql:
         condition: service_healthy
@@ -79,6 +84,7 @@ services:
         condition: service_healthy
 
   devify-scheduler:
+    image: ${DEVIFY_REGISTRY:-docker.io/oneprolabs}/devify:${DEVIFY_IMAGE_TAG:-latest}
     depends_on: !override
       mysql:
         condition: service_healthy


### PR DESCRIPTION
A rollback did not roll everything back.

`devify-api` and `devify-ui` are pinned to `DEVIFY_IMAGE_TAG` by the blue/green overlay. `devify-worker` and `devify-scheduler` are not — the base file leaves them on `:latest`, and the overlay reached them only to override `depends_on`:

```yaml
  devify-worker:
    depends_on: !override      # ← and nothing else
```

So a deploy moved them by whatever `:latest` resolved to, and a rollback left them where they were. The API would return to the retired version while the workers kept running the code being rolled away from — against the one shared database.

## Pinning alone would not have fixed it

`rollback_stack` brings up the colored services and nothing else:

```bash
compose --profile "${target}" up -d "devify-api-${target}" "devify-ui-${target}"
```

The workers are never recreated during a rollback, whatever their image reference says. So this does both: pins them in the overlay, and recreates them in `rollback_stack` under the `DEVIFY_IMAGE_TAG` it already exports for the retired version.

## Scope

The blue/green overlay only. Standalone never had this problem — `install.sh` rewrites every tag in the base file textually, and there is no rollback path there. The base compose is untouched, and its four `:latest` references still match the installer's `sed`.

Fourteen lines.

## Verified through compose

| `DEVIFY_IMAGE_TAG` | worker | scheduler |
|---|---|---|
| 1.5.4 | `…/devify:1.5.4` | `…/devify:1.5.4` |
| 1.5.3 | `…/devify:1.5.3` | `…/devify:1.5.3` |

And the base file on its own still gives `docker.io/oneprolabs/devify:latest` for a standalone install.

## Note on the first deploy after this

The workers currently run `:latest`. The next deploy pins them to the release version, which recreates them once — the same rolling restart every deploy already gives them, with celery's graceful drain letting in-flight tasks finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m