### PR TITLE
Stop the deploy reaching past its own images, and say when it downgrades

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -211,7 +211,15 @@ jobs:
             set -e
             cd ~/devify-deploy
             DEVIFY_REF=${{ github.ref_name }} ./deploy/scripts/devify-deploy.sh upgrade
-            docker system prune -f
+            # Scoped to images this repository publishes. `docker system
+            # prune -f` reaches the whole host, and this host also runs
+            # sourcelens — itself blue/green, so a colour it had stopped for
+            # inspection was a stopped container our deploy would delete.
+            # The deploy's own prune_old_images handles version retention;
+            # this only sweeps the dangling layers a moved :latest leaves,
+            # which that function deliberately skips.
+            docker image prune -f \
+              --filter "label=org.opencontainers.image.source=https://github.com/oneprolabs/devify"
 
   # Docker Hub is a convenience mirror, mainly for installs outside China
   # that would otherwise pull from Aliyun ACR. It is deliberately a separate

--- a/deploy/scripts/devify-deploy.sh
+++ b/deploy/scripts/devify-deploy.sh
@@ -274,6 +274,25 @@ ensure_nginx_certs() {
             echo "Migrated nginx certificates from docker/nginx/certs to data/certs/nginx."
             return
         fi
+        # Generating is right on a first install and wrong on a running
+        # deployment, where it means real certificates went missing. Say so
+        # rather than quietly serving a self-signed pair: this host sits
+        # behind a reverse proxy that terminates TLS to the outside, so
+        # nothing user-visible changes and nobody would notice until a
+        # client checked the chain. .active_color exists only after a
+        # deploy has run, which is what separates the two cases.
+        if [ -f "${DEPLOY_ROOT}/.active_color" ]; then
+            log "WARNING: no nginx certificates in ${DEPLOY_ROOT}/data/certs/nginx,
+  generating a self-signed pair on a deployment that has run before.
+  Likely cause: the certificates were deleted, the data directory was
+    replaced, or a restore missed data/certs/nginx.
+  Effect: nginx serves a self-signed certificate from now on. The reverse
+    proxy in front terminates TLS for external clients, so this is
+    invisible from outside until something validates the chain.
+  Try: restore the real certificate and key into
+    ${DEPLOY_ROOT}/data/certs/nginx and rerun, before this deploy is
+    treated as healthy."
+        fi
         "${SCRIPT_DIR}/generate-self-signed-certs.sh"
     fi
 }

--- a/home/docker/nginx.conf
+++ b/home/docker/nginx.conf
@@ -2,6 +2,13 @@ server {
     listen 80;
     server_name localhost;
 
+    # Send Location relative, not absolute. This server is reached over
+    # plain HTTP from the proxy in front, so nginx would build the absolute
+    # form from that scheme: a browser arriving on https://<host>/ was
+    # answered 302 http://<host>/zh/, downgraded, and bounced back to
+    # https by the outer redirect. One extra round trip, in the clear.
+    absolute_redirect off;
+
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
Three independent hygiene fixes in the deploy path — items 6, 3 and 5 from the follow-up list. 35 lines.

## The release pruned the whole host

```bash
DEVIFY_REF=... ./deploy/scripts/devify-deploy.sh upgrade
docker system prune -f          # ← everything on the machine
```

This host also runs **sourcelens** (7 containers, itself blue/green), nginx-proxy-manager and beszel-agent. `docker system prune -f` removes every stopped container and dangling image on the box — including a sourcelens colour stopped for inspection, which is their rollback asset.

Now scoped by label:

```bash
docker image prune -f \
  --filter "label=org.opencontainers.image.source=https://github.com/oneprolabs/devify"
```

Checked on the host: our images carry that label, sourcelens images carry none.

Deleting it outright would have been wrong — `prune_old_images` keeps the two newest tags plus `latest` and explicitly skips `<none>`, so dangling layers from a moved `:latest` are exactly what it does not reclaim. A scoped image prune fills that gap and nothing else.

## The certificate fallback was silent

```bash
if [ ! -f .../aimychats.com.crt ] || [ ! -f .../app.aimychats.com.crt ]; then
    ...
    "${SCRIPT_DIR}/generate-self-signed-certs.sh"     # and carry on
fi
```

Right on a first install. On a running deployment it means the real certificates went missing — deleted, a replaced data directory, a restore that skipped `data/certs/nginx` — and the deploy continued serving a self-signed pair without a word. TLS to the outside is terminated by the reverse proxy in front, so nothing user-visible changes and nobody would notice until something validated the chain.

`.active_color` exists only after a deploy has run, which separates the two cases. It now warns on the second one, and still generates, so a recovery is not blocked by it.

## The homepage downgraded its own redirect

```console
$ curl -sI https://aimychats.com/
HTTP/1.1 302 Moved Temporarily
Location: http://aimychats.com/zh/     ← http
```

nginx builds the absolute form from the scheme it was reached on, and from the proxy that is plain HTTP. The outer redirect bounced it back to https — one extra round trip, in the clear, on the landing page.

`absolute_redirect off` sends `Location: /zh/` and the browser keeps its own scheme. Verified by building and running the image:

```
HTTP/1.1 302 Moved Temporarily
Location: /zh/
```

The compose healthcheck that the blue/green switch gates on (`wget --spider http://127.0.0.1`) still exits 0 — worth checking, since it follows that redirect.

## Noted, not changed

`ensure_nginx_certs` also has a legacy branch that migrates certificates from `${DEPLOY_ROOT}/docker/nginx/certs`. That path can no longer exist: the deploy root's sparse checkout materialises only `deploy/`. It is unreachable rather than wrong, and removing it belongs with a look at the whole certificate story rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m