### PR TITLE
Move the database off a series that stopped receiving releases

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -166,3 +166,44 @@ DEVIFY_RUNTIME_ROOT="$(pwd)" .devify/scripts/manage-haraka-certs.sh status
 - `docker-compose.yml`: homepage-only Compose override.
 - `docker/nginx/aimychats.com.conf`: homepage Nginx routing.
 - `env.sample`: production environment template for the whole stack.
+
+## Upgrading MariaDB
+
+The database is a single shared service — blue/green does not cover it, so a
+version change is real downtime. Locally, an in-place 11.6.2 → 11.8.9 upgrade
+was ready in 7 seconds on an empty schema; production carries 2.2 GB, so
+expect tens of seconds rather than minutes.
+
+```bash
+# 1. back up first, and check the backup before going further
+TS=$(date +%Y%m%d-%H%M%S)
+docker exec devify-mariadb sh -c \
+  'exec mariadb-dump -uroot -p"$MYSQL_ROOT_PASSWORD" --all-databases \
+     --single-transaction --routines --events --triggers' \
+  | gzip > /apps/devify/backups/devify-full-$TS.sql.gz
+gzip -t /apps/devify/backups/devify-full-$TS.sql.gz
+
+# 2. point .env at the new image, then deploy
+#    DEVIFY_MYSQL_IMAGE=mariadb:11.8
+#    MARIADB_AUTO_UPGRADE=1
+```
+
+`MARIADB_AUTO_UPGRADE` runs `mariadb-upgrade` **on the system tables only** —
+its own log says so: *"The --upgrade-system-tables option was used, user
+tables won't be touched."* The user tables have to be checked separately, and
+this is the step that is easy to assume happened:
+
+```bash
+docker exec devify-mariadb sh -c \
+  'mariadb-check -uroot -p"$MYSQL_ROOT_PASSWORD" --check-upgrade --all-databases'
+```
+
+Every table must report `OK`. Then confirm the schema still matches the code:
+
+```bash
+docker exec devify-api-blue python manage.py migrate --check   # expect 0
+```
+
+Rolling back means restoring the dump onto the previous image. `mariadb-upgrade`
+rewrites system tables, so the running data directory does not go backwards —
+the backup from step 1 is the only way back.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -95,7 +95,7 @@ services:
     command: celery-beat
 
   mysql:
-    image: registry.cn-beijing.aliyuncs.com/oneprolabs/mariadb:11.6
+    image: registry.cn-beijing.aliyuncs.com/oneprolabs/mariadb:11.8
     container_name: devify-mariadb-dev
     restart: unless-stopped
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
       start_period: 30s
 
   mysql:
-    image: ${DEVIFY_MYSQL_IMAGE:-mariadb:11.6}
+    image: ${DEVIFY_MYSQL_IMAGE:-mariadb:11.8}
     container_name: devify-mariadb
     restart: unless-stopped
     logging: *default-logging

--- a/docker/mysql/etc/my.cnf
+++ b/docker/mysql/etc/my.cnf
@@ -16,8 +16,6 @@ sql_mode = STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION
 innodb_buffer_pool_size = 1G              # Main cache for data and indexes (~25% of total RAM)
 innodb_log_file_size = 128M               # Redo log size; good balance between safety and performance
 innodb_flush_log_at_trx_commit = 1        # 1 = safest; 2 for better performance (optional)
-innodb_file_per_table = 1                 # Each table in a separate file (recommended)
-innodb_flush_method = O_DIRECT            # Avoid double buffering
 innodb_buffer_pool_instances = 1          # Only one instance needed for small memory
 
 # ===== Temporary Tables =====

--- a/install.sh
+++ b/install.sh
@@ -867,7 +867,11 @@ registry_channel_env() {
   ensure_env_key "${env_file}" "DEVIFY_REGISTRY" "${REGISTRY}"
   if [[ "${CHANNEL}" == "cn" ]]; then
     ensure_env_key "${env_file}" "DEVIFY_NGINX_IMAGE"  "${REGISTRY_CN}/nginx:latest"
-    ensure_env_key "${env_file}" "DEVIFY_MYSQL_IMAGE"  "${REGISTRY_CN}/mariadb:11.6"
+    # Left upstream on purpose: the ACR namespace carries no 11.8 copy, and
+    # its 11.6 one is a series that stopped receiving releases in November
+    # 2024. A pull of mariadb:11.8 from inside China took 33s on the
+    # production host, which is not worth staying on an unmaintained
+    # database for. Point this at ACR once a copy is pushed there.
     ensure_env_key "${env_file}" "DEVIFY_REDIS_IMAGE"  "${REGISTRY_CN}/redis:alpine"
     ensure_env_key "${env_file}" "DEVIFY_HARAKA_IMAGE" "${REGISTRY_CN}/haraka:latest"
   fi


### PR DESCRIPTION
Production runs **MariaDB 11.6.2** from an image built **2024-11-21**.

11.6.2 was released 2024-11-22 and is the **last release that series ever had**. 11.6 is a rolling release and does not appear in [MariaDB's maintenance policy table](https://mariadb.org/about/maintenance-policy/) at all — nothing fixed in 11.x since November 2024 has been backported to it. Upstream stopped rebuilding the container in February 2025, and even that rebuild is newer than what production runs.

So the accurate framing is not "missing ten months of patches" — 11.6 has no patches to miss. It is a database sitting on a line that receives none.

## 11.8 is the only forward path

| | GA | community support | latest |
|---|---|---|---|
| **11.8 LTS** | 2025-06-04 | 2028-06-04 | 11.8.9 (2026-08-22) |
| 11.4 LTS | 2024-05-29 | 2029-05-29 | 11.4.13 (2026-08-22) |

11.4 has the longer remaining window, which is counterintuitive — but it is *older* than 11.6, and MariaDB does not support downgrading in place. Reaching it would cost a dump and restore for one extra year of support.

## Tested, not reasoned about

Restored the production schema into an 11.6.2 container on the production `my.cnf`, shut it down cleanly, started 11.8.9 on the same volume with `MARIADB_AUTO_UPGRADE=1`:

| | baseline (11.6.2) | after (11.8.9) |
|---|---|---|
| tables | 132 | **132** |
| foreign keys | 225 | **225** |
| check constraints | 205 | **205** |
| `json_valid` constraints | 179 | **179** |
| indexes | — | 568 |
| engines | InnoDB | **InnoDB** |
| collations | `utf8mb4_unicode_ci` | **`utf8mb4_unicode_ci`** |

Ready in **7 seconds**. `mariadb-check --check-upgrade` reported `OK` for all 132 tables. Django's `migrate --check` exited **0**. Writes, transactions, JSON path queries and deletes all worked against 11.8.

## Two things the test surfaced

**`MARIADB_AUTO_UPGRADE` does not check user tables.** Its own log says so:

```
The --upgrade-system-tables option was used, user tables won't be touched.
Major version upgrade detected from 11.6.2-MariaDB to 11.8.9-MariaDB. Check required!
```

`mariadb-check --check-upgrade` has to be run separately. That is exactly the step someone assumes happened, so `deploy/README` now spells it out.

**`my.cnf` carries two settings 11.8 warns about** — `innodb_file_per_table` and `innodb_flush_method`, both set to their own defaults. Removed.

## Scope of the test

Schema-shaped. The full 2.2 GB dump transfers at roughly 10 KB/s from production, so the 7 seconds is an empty-schema figure and the real upgrade will take longer — tens of seconds, since `mariadb-upgrade` reads table definitions rather than rewriting data.

Correctness is what a schema exercises, and every risk here is schema-shaped. Audited the production database directly: **zero** stored procedures, functions, triggers, views, events and generated columns; all 132 tables InnoDB; one collation throughout. The only raw SQL in the codebase is a `connection.vendor == "postgresql"` branch that never runs on MariaDB, and one `information_schema` lookup in migration 0034.

## The cn channel keeps mariadb upstream

The ACR namespace has no 11.8 copy — only the 11.6 one. Pulling `mariadb:11.8` from upstream took **33 seconds** on the production host, which is not worth staying on an unmaintained database to avoid. The reason is recorded next to the line, so it can be pointed back at ACR once a copy is pushed.

## Deploying this

`DEVIFY_MYSQL_IMAGE` in production's `.env` currently pins ACR 11.6, so **merging this changes nothing on its own** — production keeps its current database until that key is updated and the stack redeployed. The database is a single shared service, so unlike everything else this month that is real downtime, and it wants its own window with a fresh backup first. `deploy/README` has the procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m