### PR TITLE
Note that the repositories this go-live doc links to are archived

### DIFF
--- a/deploy/docs/BLUEGREEN_GOLIVE.md
+++ b/deploy/docs/BLUEGREEN_GOLIVE.md
@@ -40,6 +40,8 @@ Consequences that shape this runbook:
 ## 0. Pre-flight (no traffic impact)
 
 1. Merge both PRs: `cloud2ai/devify#18` and `cloud2ai/devify-deploy#1`.
+   (Historical. devify-deploy was merged into this repository as `deploy/`
+   and archived; both links now redirect to the oneprolabs org.)
 2. On the host: `cd ~/devify-deploy && git pull --ff-only origin main`.
 3. Record the current running version (your fallback) and back up MySQL:
    ```bash


### PR DESCRIPTION
One line. `deploy/docs/BLUEGREEN_GOLIVE.md` references PRs in `devify-deploy`, which is now `deploy/` in this repository and archived. The reference is a historical record rather than a live dependency, so it stays — but the link still resolves, so it now says where that repository went.

Checked before archiving: both old repositories had zero open issues and zero open PRs, and every stray branch (`ray`, `feature/bluegreen-issue-17`, `fix/devify-home-compose-managed`, `fix/homepage-compose-managed-deploy`) was zero commits ahead of its main. Production's two checkouts both point at `oneprolabs/devify`, so nothing at runtime depends on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SfjXVYU8YutZgh8u3jC4m