### PR TITLE
Fix metadata extraction for ingested emails

### DIFF
--- a/devify/threadline/agents/nodes/metadata_node.py
+++ b/devify/threadline/agents/nodes/metadata_node.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 from core.tracking import LLMTracker
 from threadline.agents.email_state import EmailState, add_node_error
 from threadline.agents.nodes.base_node import BaseLangGraphNode
+from threadline.agents.progress import metadata_requires_extraction
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ class MetadataNode(BaseLangGraphNode):
     - Execute LLM processing to generate structured metadata
     - Validate and normalize metadata (type checking for common list fields)
     - Update State with metadata
-    - Skip if metadata already exists (unless force mode)
+    - Skip if extracted metadata already exists (unless force mode)
     - Handle LLM errors gracefully with retries
 
     Note: Metadata field definitions are driven by prompts, not hard-coded.
@@ -117,10 +118,15 @@ class MetadataNode(BaseLangGraphNode):
         )
 
         existing_metadata = state.get("metadata")
+        should_generate_metadata = force or metadata_requires_extraction(
+            existing_metadata
+        )
         text_llm_config_uuid = state.get("text_llm_config_uuid")
 
         try:
-            if not existing_metadata or force:
+            # Email ingestion also stores parser details in ``metadata``.
+            # Those details do not mean that AI metadata was extracted.
+            if should_generate_metadata:
                 logger.info("Generating metadata from summary")
                 self._record_progress_step(
                     self.workflow_stage,

--- a/devify/threadline/agents/progress.py
+++ b/devify/threadline/agents/progress.py
@@ -23,6 +23,8 @@ WORKFLOW_STAGES = (
     "finalize",
 )
 
+INGESTION_METADATA_MARKERS = {"eml_file"}
+
 
 def _bounded_int(value: int | float | None, minimum: int = 0) -> int:
     try:
@@ -33,6 +35,14 @@ def _bounded_int(value: int | float | None, minimum: int = 0) -> int:
 
 def _has_value(value) -> bool:
     return value not in (None, "", [], {})
+
+
+def metadata_requires_extraction(metadata) -> bool:
+    """Return whether metadata is absent or only describes email ingestion."""
+    is_ingestion_metadata = isinstance(
+        metadata, Mapping
+    ) and INGESTION_METADATA_MARKERS.issubset(metadata)
+    return not _has_value(metadata) or is_ingestion_metadata
 
 
 def _attachment_is_pending(attachment) -> bool:
@@ -101,7 +111,7 @@ def estimate_initial_workflow_units(
             ),
             (
                 "metadata",
-                1 if force or not _has_value(email.metadata) else 0,
+                1 if force or metadata_requires_extraction(email.metadata) else 0,
             ),
             ("finalize", 1),
         ]
@@ -171,7 +181,7 @@ def estimate_prepare_workflow_units(
             ),
             (
                 "metadata",
-                1 if force or not _has_value(metadata) else 0,
+                1 if force or metadata_requires_extraction(metadata) else 0,
             ),
             ("finalize", 1),
         ]

--- a/devify/threadline/tests/unit/test_metadata_node.py
+++ b/devify/threadline/tests/unit/test_metadata_node.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from threadline.agents.email_state import has_node_errors
+from threadline.agents.nodes.metadata_node import MetadataNode
+from threadline.agents.progress import (
+    estimate_initial_workflow_units,
+    estimate_prepare_workflow_units,
+)
+
+
+def _state(metadata):
+    return {
+        "subject": "Build notification",
+        "summary_title": "Build completed",
+        "summary_content": "The release build completed successfully.",
+        "prompt_config": {"metadata_prompt": "Extract metadata"},
+        "text_llm_config_uuid": None,
+        "metadata": metadata,
+        "node_errors": {},
+        "force": False,
+    }
+
+
+@patch("threadline.agents.nodes.metadata_node.LLMTracker.call_and_track")
+def test_ingestion_metadata_does_not_skip_metadata_extraction(mock_call):
+    mock_call.return_value = (
+        {
+            "category": "Infrastructure",
+            "participants": [],
+            "timeline": [],
+            "keywords": ["release build"],
+        },
+        {},
+    )
+    state = _state(
+        {
+            "content_type": "message/rfc822",
+            "eml_file": "/tmp/email.eml",
+            "original_size": 1024,
+            "saved_size": 1024,
+        }
+    )
+
+    result = MetadataNode()(state)
+
+    assert result["metadata"] == mock_call.return_value[0]
+    assert not has_node_errors(result)
+    mock_call.assert_called_once()
+
+
+@patch("threadline.agents.nodes.metadata_node.LLMTracker.call_and_track")
+def test_custom_extracted_metadata_is_reused(mock_call):
+    metadata = {"custom_tags": ["feedback"]}
+
+    result = MetadataNode()(_state(metadata))
+
+    assert result["metadata"] == metadata
+    mock_call.assert_not_called()
+
+
+def test_ingestion_metadata_is_included_in_progress_estimates():
+    ingestion_metadata = {"eml_file": "/tmp/email.eml"}
+    attachments = Mock()
+    attachments.filter.return_value = []
+    email = SimpleNamespace(
+        attachments=attachments,
+        text_content="",
+        llm_content=None,
+        summary_title="Build completed",
+        summary_data={"details": "Done"},
+        metadata=ingestion_metadata,
+    )
+
+    initial_units = estimate_initial_workflow_units(email=email)
+    prepared_units = estimate_prepare_workflow_units(
+        state={
+            "attachments": [],
+            "summary_title": email.summary_title,
+            "summary_data": email.summary_data,
+            "metadata": ingestion_metadata,
+        }
+    )
+
+    assert initial_units["metadata"] == 1
+    assert prepared_units["metadata"] == 1


### PR DESCRIPTION
## Summary
- distinguish Haraka ingestion metadata from previously extracted business metadata
- run metadata extraction and account for its work in both progress estimates
- preserve legacy custom metadata reuse and add focused regression coverage

Closes #71

## Test plan
- [x] Metadata extraction and reuse regression tests
- [x] Initial and prepared workflow progress estimation tests
- [x] Related backend tests (`6 passed`)
- [x] `git diff --check`
- [x] Independent `codex review --uncommitted` found no remaining regressions
