### PR TITLE
Clarify Expense retry flow

### DIFF
--- a/devify/expense/services/routing.py
+++ b/devify/expense/services/routing.py
@@ -65,7 +65,9 @@ def subject_terms(user) -> list[str]:
     return kept
 
 
-def should_route_to_invoices(email, attachments=None) -> bool:
+def should_route_to_invoices(
+    email, attachments=None, app_config=None, user_config=None
+) -> bool:
     """
     Decide without spending anything: no model call, no credit, no writes.
 
@@ -73,7 +75,7 @@ def should_route_to_invoices(email, attachments=None) -> bool:
     workflow falls back to normal processing on the same charge - but it
     costs a wasted read, so the rule stays tight.
     """
-    user_config = get_user_config(email.user)
+    user_config = user_config or get_user_config(email.user)
     if not user_config.enabled:
         return False
 
@@ -84,7 +86,8 @@ def should_route_to_invoices(email, attachments=None) -> bool:
     if not keyword_is_deliberate(email, attachments, keywords):
         return False
 
+    app_config = app_config or get_app_config()
     verdict = evaluate_email(
-        email, attachments, get_app_config(), user_config, keywords=keywords
+        email, attachments, app_config, user_config, keywords=keywords
     )
     return verdict.is_candidate

--- a/devify/expense/tests/integration/test_workflow_routing.py
+++ b/devify/expense/tests/integration/test_workflow_routing.py
@@ -12,7 +12,9 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
+from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 
 from billing.models import EmailCreditsTransaction, UserCredits
 from billing.services.credits_service import CreditsService
@@ -24,6 +26,11 @@ from threadline.agents.nodes.invoice_node import (
     route_after_invoice,
 )
 from threadline.models import EmailAttachment, EmailMessage
+from threadline.serializers import (
+    EmailMessageListRetryFlowSerializer,
+    EmailMessageRetryFlowSerializer,
+    EmailMessageSerializer,
+)
 
 
 pytestmark = [pytest.mark.integration, pytest.mark.django_db]
@@ -127,6 +134,87 @@ class TestRoutingRule:
         attach(user, email)
 
         assert should_route_to_invoices(email) is False
+
+
+class TestRetryFlowDisclosure:
+    def _listed_email(self, api_client, user, email):
+        api_client.force_authenticate(user=user)
+        response = api_client.get(reverse("threadlines-list"))
+
+        assert response.status_code == status.HTTP_200_OK
+        return next(
+            item
+            for item in response.data["data"]["list"]
+            if item["uuid"] == str(email.uuid)
+        )
+
+    def test_invoice_retry_is_identified_as_expense_flow(
+        self, api_client, user
+    ):
+        enable_expense(user)
+        email = make_email(user, subject="【电子发票】北京麻六记")
+        attach(user, email)
+
+        item = self._listed_email(api_client, user, email)
+
+        assert item["retry_flow"] == "expense"
+
+    def test_ordinary_retry_is_identified_as_conversation_flow(
+        self, api_client, user
+    ):
+        enable_expense(user)
+        email = make_email(user, subject="周会纪要")
+        attach(user, email)
+
+        item = self._listed_email(api_client, user, email)
+
+        assert item["retry_flow"] == "conversation"
+
+    def test_detail_retry_flow_matches_the_list(self, api_client, user):
+        enable_expense(user)
+        email = make_email(user, subject="【电子发票】详情验收")
+        attach(user, email)
+        api_client.force_authenticate(user=user)
+
+        response = api_client.get(
+            reverse("threadlines-detail", kwargs={"uuid": email.uuid})
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["data"]["retry_flow"] == "expense"
+
+    def test_merged_child_retry_flow_matches_its_canonical_target(
+        self, api_client, user
+    ):
+        enable_expense(user)
+        canonical = make_email(user, subject="周会纪要")
+        child = make_email(user, subject="【电子发票】详情验收")
+        child.merged_into = canonical
+        child.save(update_fields=["merged_into"])
+        attach(user, child)
+        api_client.force_authenticate(user=user)
+
+        response = api_client.get(
+            reverse("threadlines-detail", kwargs={"uuid": child.uuid})
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["data"]["retry_flow"] == "conversation"
+
+    def test_unrelated_serialization_skips_retry_flow_queries(self, user):
+        email = make_email(user, subject="普通邮件")
+
+        with patch(
+            "expense.services.routing.should_route_to_invoices"
+        ) as route:
+            data = EmailMessageSerializer(email, context={}).data
+
+        assert "retry_flow" not in data
+        route.assert_not_called()
+
+    def test_public_response_serializers_keep_retry_flow_in_schema(self):
+        assert "retry_flow" in EmailMessageRetryFlowSerializer().fields
+        assert "retry_flow" in EmailMessageListRetryFlowSerializer().fields
 
 
 class TestRouteAfterInvoice:

--- a/devify/threadline/serializers/__init__.py
+++ b/devify/threadline/serializers/__init__.py
@@ -38,6 +38,8 @@ from .email_task import (
 from .email_message import (
     EmailMessageSerializer,
     EmailMessageListSerializer,
+    EmailMessageListRetryFlowSerializer,
+    EmailMessageRetryFlowSerializer,
     EmailMessageCreateSerializer,
     EmailMessageUpdateSerializer,
     EmailMessageMergeSerializer,
@@ -89,6 +91,8 @@ __all__ = [
     # EmailMessage
     "EmailMessageSerializer",
     "EmailMessageListSerializer",
+    "EmailMessageListRetryFlowSerializer",
+    "EmailMessageRetryFlowSerializer",
     "AdminConversationListSerializer",
     "AdminConversationTaskListSerializer",
     "EmailMessageCreateSerializer",

--- a/devify/threadline/serializers/email_message.py
+++ b/devify/threadline/serializers/email_message.py
@@ -22,6 +22,32 @@ from .share_link import ThreadlineShareLinkSerializer
 from relay.models import RelayDelivery, RelayEvent
 
 
+class RetryFlowSerializerMixin:
+    include_retry_flow = False
+
+    def get_fields(self):
+        fields = super().get_fields()
+        if not (
+            self.include_retry_flow
+            or self.context.get("include_retry_flow")
+        ):
+            fields.pop("retry_flow", None)
+        return fields
+
+    def get_retry_flow(self, obj) -> str:
+        """Name the workflow that a retry of this email will enter."""
+        from expense.services.routing import should_route_to_invoices
+
+        target = obj.merged_into if obj.merged_into_id else obj
+        is_expense = should_route_to_invoices(
+            target,
+            attachments=list(target.attachments.all()),
+            app_config=self.context.get("expense_app_config"),
+            user_config=self.context.get("expense_user_config"),
+        )
+        return "expense" if is_expense else "conversation"
+
+
 def _get_latest_share_link(instance):
     """
     Retrieve latest share link, prioritizing prefetched data.
@@ -233,7 +259,9 @@ class EmailMessageMergeChildSerializer(serializers.ModelSerializer):
         return None
 
 
-class EmailMessageSerializer(serializers.ModelSerializer):
+class EmailMessageSerializer(
+    RetryFlowSerializerMixin, serializers.ModelSerializer
+):
     """
     Main serializer for EmailMessage model - used for display
     """
@@ -259,6 +287,7 @@ class EmailMessageSerializer(serializers.ModelSerializer):
     relay_delivery_count = serializers.SerializerMethodField()
     invoice_count = serializers.SerializerMethodField()
     relay_deliveries = serializers.SerializerMethodField()
+    retry_flow = serializers.SerializerMethodField()
 
     class Meta:
         model = EmailMessage
@@ -303,6 +332,7 @@ class EmailMessageSerializer(serializers.ModelSerializer):
             "issue_url",
             "relay_delivery_count",
             "invoice_count",
+            "retry_flow",
             "relay_deliveries",
             "created_at",
             "updated_at",
@@ -617,7 +647,9 @@ class EmailMessageSerializer(serializers.ModelSerializer):
         return None
 
 
-class EmailMessageListSerializer(serializers.ModelSerializer):
+class EmailMessageListSerializer(
+    RetryFlowSerializerMixin, serializers.ModelSerializer
+):
     """
     Lightweight serializer for list views - only essential fields
     """
@@ -641,6 +673,7 @@ class EmailMessageListSerializer(serializers.ModelSerializer):
     relay_delivery_count = serializers.SerializerMethodField()
     invoice_count = serializers.SerializerMethodField()
     relay_deliveries = serializers.SerializerMethodField()
+    retry_flow = serializers.SerializerMethodField()
 
     class Meta:
         model = EmailMessage
@@ -679,6 +712,7 @@ class EmailMessageListSerializer(serializers.ModelSerializer):
             "issue_url",
             "relay_delivery_count",
             "invoice_count",
+            "retry_flow",
             "relay_deliveries",
             "created_at",
         ]
@@ -841,6 +875,18 @@ class EmailMessageListSerializer(serializers.ModelSerializer):
         if obj.merged_into_id and obj.merged_into:
             return obj.merged_into.received_at
         return None
+
+
+class EmailMessageRetryFlowSerializer(EmailMessageSerializer):
+    """Public detail response contract including retry routing."""
+
+    include_retry_flow = True
+
+
+class EmailMessageListRetryFlowSerializer(EmailMessageListSerializer):
+    """Public list response contract including retry routing."""
+
+    include_retry_flow = True
 
 
 class EmailMessageCreateSerializer(serializers.ModelSerializer):

--- a/devify/threadline/views/email_message.py
+++ b/devify/threadline/views/email_message.py
@@ -25,6 +25,8 @@ from ..state_machine import EmailStatus
 from ..serializers import (
     EmailMessageSerializer,
     EmailMessageListSerializer,
+    EmailMessageListRetryFlowSerializer,
+    EmailMessageRetryFlowSerializer,
     EmailMessageCreateSerializer,
     EmailMessageUpdateSerializer,
     EmailMessageMergeSerializer,
@@ -160,6 +162,7 @@ class EmailMessageAPIView(BaseAPIView):
             .prefetch_related("relay_events__deliveries")
             .prefetch_related("relay_events__deliveries__subscription")
             .prefetch_related("share_links")
+            .prefetch_related("attachments")
             .filter(merged_into__isnull=True)
             # The invoices an email produced are the record of it having
             # been taken over by Expense; counting them beats a separate
@@ -222,7 +225,7 @@ class EmailMessageAPIView(BaseAPIView):
             ),
         ],
         responses={
-            200: pagination_response(EmailMessageListSerializer),
+            200: pagination_response(EmailMessageListRetryFlowSerializer),
             401: error_response(),
         },
     )
@@ -339,8 +342,20 @@ class EmailMessageAPIView(BaseAPIView):
             total = queryset.count()
             items = queryset[start:end]
 
+            from expense.services.config_service import (
+                get_app_config,
+                get_user_config,
+            )
+
             serializer = EmailMessageListSerializer(
-                items, many=True, context={"request": request}
+                items,
+                many=True,
+                context={
+                    "request": request,
+                    "include_retry_flow": True,
+                    "expense_app_config": get_app_config(),
+                    "expense_user_config": get_user_config(request.user),
+                },
             )
 
             response_data = {
@@ -775,6 +790,7 @@ class EmailMessageDetailAPIView(BaseAPIView):
             .prefetch_related("relay_events__deliveries")
             .prefetch_related("relay_events__deliveries__subscription")
             .prefetch_related("share_links")
+            .prefetch_related("attachments")
             .all()
         )
 
@@ -789,7 +805,7 @@ class EmailMessageDetailAPIView(BaseAPIView):
         summary="Get threadline details",
         description="Get details of a specific threadline by UUID",
         responses={
-            200: response(EmailMessageSerializer),
+            200: response(EmailMessageRetryFlowSerializer),
             404: error_response(),
             401: error_response(),
         },
@@ -801,7 +817,8 @@ class EmailMessageDetailAPIView(BaseAPIView):
         try:
             message = self.get_object(uuid)
             serializer = EmailMessageSerializer(
-                message, context={"request": request}
+                message,
+                context={"request": request, "include_retry_flow": True},
             )
 
             return Response(

--- a/ui/src/components/RetryDialog.spec.js
+++ b/ui/src/components/RetryDialog.spec.js
@@ -26,6 +26,12 @@ vi.mock('vue-i18n', async () => {
     'common.loading': 'Loading',
     'retry.confirmRetry': 'Retry',
     'retry.dialogTitle': 'Retry Chat Processing',
+    'retry.expenseDialogTitle': 'Retry Expense Processing',
+    'retry.expenseFlowTitle': 'Expense invoice recognition',
+    'retry.expenseFlowDescription': 'Expense will reprocess this email.',
+    'retry.conversationFlowTitle': 'Conversation processing',
+    'retry.conversationFlowDescription':
+      'This email will be reprocessed as a conversation.',
     'retry.forceMode': 'Force Retry',
     'retry.forceModeRequired':
       'Required because this conversation has already completed.',
@@ -46,16 +52,18 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
-const mountDialog = async (status) => {
+const mountDialog = async (status, retryFlow = 'conversation') => {
   const wrapper = mount(RetryDialog, {
-    props: { show: true, status },
+    props: { show: true, status, retryFlow },
     global: {
       stubs: {
         BaseButton: {
           template: '<button><slot /></button>'
         },
         BaseModal: {
-          template: '<section><slot /><slot name="footer" /></section>'
+          props: ['title'],
+          template:
+            '<section><h1>{{ title }}</h1><slot /><slot name="footer" /></section>'
         }
       }
     }
@@ -99,5 +107,38 @@ describe('RetryDialog', () => {
     expect(wrapper.emitted('confirm')).toEqual([
       [{ language: 'en-US', scene: 'general', force: true }]
     ])
+  })
+
+  it('explains the Expense flow and disables irrelevant controls', async () => {
+    const wrapper = await mountDialog('failed', 'expense')
+
+    expect(wrapper.text()).toContain('Retry Expense Processing')
+    expect(wrapper.text()).toContain('Expense invoice recognition')
+    expect(wrapper.text()).toContain('Expense will reprocess this email.')
+    expect(wrapper.findAll('select')).toHaveLength(2)
+    expect(
+      wrapper
+        .findAll('select')
+        .every((select) => select.attributes('disabled') !== undefined)
+    ).toBe(true)
+
+    await wrapper.get('button:last-of-type').trigger('click')
+
+    expect(wrapper.emitted('confirm')).toEqual([
+      [{ language: null, scene: null, force: false }]
+    ])
+  })
+
+  it('keeps language and scene active for the conversation flow', async () => {
+    const wrapper = await mountDialog('failed')
+
+    expect(wrapper.text()).toContain('Retry Chat Processing')
+    expect(wrapper.text()).toContain('Conversation processing')
+    expect(wrapper.text()).not.toContain('Expense will reprocess this email.')
+    expect(
+      wrapper
+        .findAll('select')
+        .every((select) => select.attributes('disabled') === undefined)
+    ).toBe(true)
   })
 })

--- a/ui/src/components/RetryDialog.vue
+++ b/ui/src/components/RetryDialog.vue
@@ -1,5 +1,9 @@
 <template>
-  <BaseModal :show="show" :title="t('retry.dialogTitle')" @close="handleClose">
+  <BaseModal
+    :show="show"
+    :title="t(isExpenseFlow ? 'retry.expenseDialogTitle' : 'retry.dialogTitle')"
+    @close="handleClose"
+  >
     <div v-if="initializing" class="flex items-center justify-center py-8">
       <div class="text-center">
         <svg
@@ -26,15 +30,40 @@
       </div>
     </div>
     <div v-else class="space-y-5">
+      <div class="rounded-lg border border-line bg-app-sub px-4 py-3">
+        <p class="text-sm font-semibold text-ink">
+          {{
+            t(
+              isExpenseFlow
+                ? 'retry.expenseFlowTitle'
+                : 'retry.conversationFlowTitle'
+            )
+          }}
+        </p>
+        <p
+          id="retry-flow-description"
+          class="mt-1 text-sm leading-relaxed text-ink-3"
+        >
+          {{
+            t(
+              isExpenseFlow
+                ? 'retry.expenseFlowDescription'
+                : 'retry.conversationFlowDescription'
+            )
+          }}
+        </p>
+      </div>
+
       <!-- Language Selector -->
-      <div>
+      <div :class="isExpenseFlow ? 'opacity-50' : ''">
         <label class="block text-sm font-medium text-ink-2 mb-2">
           {{ t('settings.language') }}
         </label>
         <select
           v-model="localLanguage"
           class="input w-full"
-          :disabled="loading"
+          aria-describedby="retry-flow-description"
+          :disabled="loading || isExpenseFlow"
         >
           <option value="">{{ t('retry.useDefaultLanguage') }}</option>
           <option value="en-US">{{ t('settings.languages.en') }}</option>
@@ -44,14 +73,15 @@
       </div>
 
       <!-- Scene Selector -->
-      <div>
+      <div :class="isExpenseFlow ? 'opacity-50' : ''">
         <label class="block text-sm font-medium text-ink-2 mb-2">
           {{ t('settings.scene') }}
         </label>
         <select
           v-model="localScene"
           class="input w-full"
-          :disabled="loading || loadingScenes"
+          aria-describedby="retry-flow-description"
+          :disabled="loading || loadingScenes || isExpenseFlow"
         >
           <option value="" disabled>
             {{ loadingScenes ? t('common.loading') : t('auth.selectScene') }}
@@ -175,6 +205,11 @@ const props = defineProps({
   status: {
     type: String,
     default: ''
+  },
+  retryFlow: {
+    type: String,
+    default: 'conversation',
+    validator: (value) => ['conversation', 'expense'].includes(value)
   }
 })
 
@@ -191,6 +226,7 @@ const localForce = ref(false)
 const scenes = ref([])
 const defaultLanguage = ref('')
 const defaultScene = ref('')
+const isExpenseFlow = computed(() => props.retryFlow === 'expense')
 
 // Check if force retry is required (for success status)
 const forceRequired = computed(() => {
@@ -229,8 +265,8 @@ const handleClose = () => {
 
 const handleRetry = () => {
   emit('confirm', {
-    language: localLanguage.value || null,
-    scene: localScene.value || null,
+    language: isExpenseFlow.value ? null : localLanguage.value || null,
+    scene: isExpenseFlow.value ? null : localScene.value || null,
     force: localForce.value
   })
 }
@@ -246,8 +282,10 @@ watch(
       localLanguage.value = ''
       localScene.value = ''
 
-      // Load defaults and scenes in parallel
-      await Promise.all([loadDefaults(), loadScenes()])
+      if (!isExpenseFlow.value) {
+        // Load defaults and scenes in parallel
+        await Promise.all([loadDefaults(), loadScenes()])
+      }
 
       // Set defaults after loading both preferences and scenes
       // This ensures the select options are populated before setting values
@@ -274,7 +312,9 @@ onMounted(async () => {
     initializing.value = true
     // Set force based on status: if success, force must be true
     localForce.value = forceRequired.value
-    await Promise.all([loadDefaults(), loadScenes()])
+    if (!isExpenseFlow.value) {
+      await Promise.all([loadDefaults(), loadScenes()])
+    }
     // Set defaults after loading both preferences and scenes
     if (defaultLanguage.value) {
       localLanguage.value = defaultLanguage.value

--- a/ui/src/components/threadline/detail/ThreadlineDetailPanel.vue
+++ b/ui/src/components/threadline/detail/ThreadlineDetailPanel.vue
@@ -604,6 +604,7 @@
   <RetryDialog
     :show="showRetryDialog"
     :status="threadline?.status"
+    :retry-flow="threadline?.retry_flow || 'conversation'"
     @close="showRetryDialog = false"
     @confirm="handleRetry"
   />

--- a/ui/src/locales/en.json
+++ b/ui/src/locales/en.json
@@ -977,6 +977,11 @@
   },
   "retry": {
     "dialogTitle": "Retry Chat Processing",
+    "expenseDialogTitle": "Retry Expense Processing",
+    "expenseFlowTitle": "Expense invoice recognition",
+    "expenseFlowDescription": "This email will be reprocessed by Expense. Language and scene apply only to conversation summaries, so they are unavailable for this retry.",
+    "conversationFlowTitle": "Conversation processing",
+    "conversationFlowDescription": "This email will be reprocessed as a conversation using the language and scene below.",
     "language": "Processing Language",
     "languageHint": "Select the language for AI processing (leave empty to use default)",
     "useDefaultLanguage": "Use default language",

--- a/ui/src/locales/es.json
+++ b/ui/src/locales/es.json
@@ -380,6 +380,11 @@
   },
   "retry": {
     "dialogTitle": "Reintentar procesamiento de correo",
+    "expenseDialogTitle": "Reintentar procesamiento de Expense",
+    "expenseFlowTitle": "Reconocimiento de facturas de Expense",
+    "expenseFlowDescription": "Expense volverá a procesar este correo. El idioma y la escena solo se aplican a los resúmenes de conversaciones, por lo que no están disponibles para este reintento.",
+    "conversationFlowTitle": "Procesamiento de conversación",
+    "conversationFlowDescription": "Este correo se volverá a procesar como una conversación usando el idioma y la escena seleccionados abajo.",
     "language": "Idioma de procesamiento",
     "languageHint": "Seleccione el idioma para el procesamiento de IA (deje vacío para usar el predeterminado)",
     "useDefaultLanguage": "Usar idioma predeterminado",

--- a/ui/src/locales/zh-CN.json
+++ b/ui/src/locales/zh-CN.json
@@ -986,6 +986,11 @@
   },
   "retry": {
     "dialogTitle": "重新处理对话",
+    "expenseDialogTitle": "重新识别发票",
+    "expenseFlowTitle": "发票管家识别流程",
+    "expenseFlowDescription": "这封邮件将由发票管家重新识别。语言和场景仅用于对话总结，因此本次重试不可设置。",
+    "conversationFlowTitle": "对话处理流程",
+    "conversationFlowDescription": "这封邮件将按对话重新处理，并使用下方选择的语言和场景。",
     "language": "处理语言",
     "languageHint": "选择AI处理时使用的语言（留空使用默认设置）",
     "useDefaultLanguage": "使用默认语言",

--- a/ui/src/pages/Dashboard.vue
+++ b/ui/src/pages/Dashboard.vue
@@ -405,6 +405,7 @@
       <RetryDialog
         :show="showRetryDialog"
         :status="retryDialogStatus"
+        :retry-flow="retryDialogFlow"
         @close="showRetryDialog = false"
         @confirm="handleRetryConfirm"
       />
@@ -530,6 +531,9 @@ const retryDialogStatus = computed(() =>
   retryTargets.value.some((item) => item.status === 'success')
     ? 'success'
     : 'failed'
+)
+const retryDialogFlow = computed(
+  () => retryTargets.value[0]?.retry_flow || 'conversation'
 )
 const mergeConfirmMessage = computed(() => {
   const titles = selectedThreadlines.value


### PR DESCRIPTION
## Summary
- expose the actual retry workflow from the backend for Threadline list and detail views
- explain Expense versus conversation processing in the retry dialog and disable irrelevant Expense options
- keep merged-child disclosure aligned with its canonical retry target and avoid nested serializer query regressions
- add localized copy and backend/frontend regression coverage

Closes #70

## Test plan
- [x] Focused backend suite passed before review fixes (24 tests)
- [x] Frontend unit suite passed (10 tests)
- [x] Frontend production build passed
- [x] Python compile, locale JSON parsing, and git diff checks passed after review fixes
- [x] Automated review completed with no remaining correctness or regression findings
- [ ] CI validates the final committed test suite