### PR TITLE
Keep todo filter menus visible outside the filter bar

### DIFF
--- a/ui/src/components/ui/FilterSelect.spec.js
+++ b/ui/src/components/ui/FilterSelect.spec.js
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import FilterSelect from './FilterSelect.vue'
+
+describe('FilterSelect', () => {
+  let wrapper
+
+  afterEach(() => {
+    wrapper?.unmount()
+    document.body
+      .querySelectorAll('[data-filter-select-menu]')
+      .forEach((menu) => menu.remove())
+  })
+
+  it('teleports the open menu outside clipping ancestors and selects an option', async () => {
+    wrapper = mount(FilterSelect, {
+      attachTo: document.body,
+      props: {
+        label: '状态：全部',
+        options: [
+          { value: null, label: '全部' },
+          { value: false, label: '未完成' },
+          { value: true, label: '已完成' }
+        ],
+        modelValue: null,
+        size: 'sm'
+      }
+    })
+
+    await wrapper.get('button').trigger('click')
+
+    const menu = document.body.querySelector('[data-filter-select-menu]')
+    expect(menu).not.toBeNull()
+    expect(menu.parentElement).toBe(document.body)
+    expect(menu.querySelectorAll('button')).toHaveLength(3)
+
+    menu.querySelectorAll('button')[1].click()
+    await flushPromises()
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]])
+    expect(document.body.querySelector('[data-filter-select-menu]')).toBeNull()
+  })
+})

--- a/ui/src/components/ui/FilterSelect.vue
+++ b/ui/src/components/ui/FilterSelect.vue
@@ -1,6 +1,7 @@
 <template>
   <div ref="root" class="relative">
     <button
+      ref="trigger"
       type="button"
       class="flex items-center gap-1.5 rounded-md border border-line text-ink-2 transition-colors hover:border-ink-4"
       :class="
@@ -8,7 +9,7 @@
           ? 'h-[30px] bg-panel px-[11px] text-xs'
           : 'h-8 px-[11px] text-[calc(12.5px*var(--fs))]'
       "
-      @click="open = !open"
+      @click="toggleOpen"
     >
       {{ label }}
       <svg
@@ -23,21 +24,25 @@
       </svg>
     </button>
 
-    <div
-      v-if="open"
-      class="absolute right-0 z-30 mt-1 min-w-[150px] rounded-md border border-line bg-panel py-1 shadow-soft-md"
-    >
-      <button
-        v-for="option in options"
-        :key="String(option.value)"
-        type="button"
-        class="flex w-full items-center px-3 py-1.5 text-left text-[calc(12.5px*var(--fs))] transition-colors hover:bg-chip"
-        :class="option.value === modelValue ? 'text-accent' : 'text-ink-2'"
-        @click="pick(option.value)"
+    <Teleport to="body">
+      <div
+        v-if="open"
+        data-filter-select-menu
+        class="fixed z-30 min-w-[150px] rounded-md border border-line bg-panel py-1 shadow-soft-md"
+        :style="menuStyle"
       >
-        {{ option.label }}
-      </button>
-    </div>
+        <button
+          v-for="option in options"
+          :key="String(option.value)"
+          type="button"
+          class="flex w-full items-center px-3 py-1.5 text-left text-[calc(12.5px*var(--fs))] transition-colors hover:bg-chip"
+          :class="option.value === modelValue ? 'text-accent' : 'text-ink-2'"
+          @click="pick(option.value)"
+        >
+          {{ option.label }}
+        </button>
+      </div>
+    </Teleport>
   </div>
 </template>
 
@@ -57,19 +62,61 @@ defineProps({
 const emit = defineEmits(['update:modelValue'])
 
 const root = ref(null)
+const trigger = ref(null)
 const open = ref(false)
+const menuStyle = ref({})
+
+const updateMenuPosition = () => {
+  if (!trigger.value || typeof window === 'undefined') return
+
+  const rect = trigger.value.getBoundingClientRect()
+  menuStyle.value = {
+    top: `${rect.bottom + 4}px`,
+    right: `${Math.max(8, window.innerWidth - rect.right)}px`
+  }
+}
+
+const removePositionListeners = () => {
+  if (typeof window === 'undefined') return
+  window.removeEventListener('resize', updateMenuPosition)
+  window.removeEventListener('scroll', updateMenuPosition, true)
+}
+
+const addPositionListeners = () => {
+  if (typeof window === 'undefined') return
+  window.addEventListener('resize', updateMenuPosition)
+  window.addEventListener('scroll', updateMenuPosition, true)
+}
+
+const close = () => {
+  open.value = false
+  removePositionListeners()
+}
+
+const toggleOpen = () => {
+  open.value = !open.value
+  if (open.value) {
+    updateMenuPosition()
+    addPositionListeners()
+  } else {
+    close()
+  }
+}
 
 const pick = (value) => {
   emit('update:modelValue', value)
-  open.value = false
+  close()
 }
 
 const closeOnOutside = (event) => {
   if (open.value && root.value && !root.value.contains(event.target)) {
-    open.value = false
+    close()
   }
 }
 
 onMounted(() => document.addEventListener('click', closeOnOutside))
-onBeforeUnmount(() => document.removeEventListener('click', closeOnOutside))
+onBeforeUnmount(() => {
+  document.removeEventListener('click', closeOnOutside)
+  removePositionListeners()
+})
 </script>


### PR DESCRIPTION
## Summary
- render Todo status, priority, and group-by menus outside the filter bar's overflow container
- position the teleported menu against its trigger and keep it aligned during resize or scroll
- clean up menu positioning listeners when the menu closes or the component unmounts
- add a component regression test covering menu visibility and option selection

Closes #78

## Test plan
- [x] `npm run test:unit` (6 files, 13 tests)
- [x] `npx eslint src/components/ui/FilterSelect.vue src/components/ui/FilterSelect.spec.js`
- [x] `npm run build`
- [x] `git diff --check`
- [x] ego-browser: verified the Todo status menu at a narrow desktop viewport; all options are visible and clickable
- [x] ego-browser: selected `未完成` and verified the filter label updates correctly
- [ ] Full frontend lint: blocked by 33 pre-existing errors outside this change
- [ ] Full backend pytest: 1154 passed, 32 unrelated existing failures, 7 skipped

## Implementation notes
`FilterSelect` previously rendered an absolutely positioned menu inside the Todo
filter bar. The bar uses `overflow-x-auto`, which also clips descendants on the
vertical axis. The menu is now teleported to `body` and positioned with
`position: fixed`, so it is no longer constrained by the filter bar.
