### PR TITLE
Add safe restart and recreate commands for blue-green deployments

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -83,6 +83,7 @@ DEVIFY_REPO=https://github.com/oneprolabs/devify.git DEVIFY_REF=main \
 ./deploy/scripts/devify-deploy.sh logs
 ./deploy/scripts/devify-deploy.sh logs devify-api
 ./deploy/scripts/devify-deploy.sh restart
+./deploy/scripts/devify-deploy.sh recreate
 ./deploy/scripts/devify-deploy.sh stop
 ./deploy/scripts/devify-deploy.sh start
 ./deploy/scripts/devify-deploy.sh config

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -10,8 +10,14 @@ Use `devify-deploy.sh` for install, upgrade, and daily operations:
 ./deploy/scripts/devify-deploy.sh status
 ./deploy/scripts/devify-deploy.sh logs
 ./deploy/scripts/devify-deploy.sh restart
+./deploy/scripts/devify-deploy.sh recreate
 ./deploy/scripts/devify-deploy.sh config
 ```
+
+`restart` only restarts existing containers. `recreate` applies the current
+Compose configuration with `--force-recreate` and preserves data volumes; it
+does not pull new images. Pass service names to limit either operation, for
+example `recreate devify-api devify-worker`.
 
 Environment overrides:
 

--- a/deploy/scripts/devify-deploy.sh
+++ b/deploy/scripts/devify-deploy.sh
@@ -558,6 +558,65 @@ update_home() {
     log "devify-home refreshed."
 }
 
+# The blue/green overlay keeps the base API and UI services on the `single`
+# profile. Resolve their logical names to whichever color currently serves
+# traffic so operational commands do not accidentally target the parked
+# single-service definitions.
+runtime_service_name() {
+    local service="$1" active="$2"
+    case "${service}" in
+        devify-api)
+            echo "devify-api-${active}"
+            ;;
+        devify-ui)
+            echo "devify-ui-${active}"
+            ;;
+        *)
+            echo "${service}"
+            ;;
+    esac
+}
+
+restart_stack() {
+    acquire_deploy_lock
+    check_requirements
+    ensure_env
+    ensure_stack_files
+
+    local active service
+    local services=()
+    active="$(current_color)"
+    for service in "$@"; do
+        services+=("$(runtime_service_name "${service}" "${active}")")
+    done
+
+    if [ "${#services[@]}" -eq 0 ]; then
+        compose --profile "${active}" restart
+    else
+        compose --profile "${active}" restart "${services[@]}"
+    fi
+}
+
+recreate_stack() {
+    acquire_deploy_lock
+    check_requirements
+    ensure_env
+    ensure_stack_files
+
+    local active service
+    local services=()
+    active="$(current_color)"
+    for service in "$@"; do
+        services+=("$(runtime_service_name "${service}" "${active}")")
+    done
+
+    if [ "${#services[@]}" -eq 0 ]; then
+        compose --profile "${active}" up -d --force-recreate
+    else
+        compose --profile "${active}" up -d --force-recreate "${services[@]}"
+    fi
+}
+
 show_usage() {
     cat <<'USAGE'
 Usage: ./deploy/scripts/devify-deploy.sh <command> [--local] [args]
@@ -572,6 +631,7 @@ Commands:
   start        Start the deployment stack
   stop         Stop the deployment stack
   restart      Restart the deployment stack
+  recreate     Force recreate the deployment stack without removing volumes
   logs         Show logs; extra args are passed to docker compose logs
   manage       Run a Django management command in the devify-api container
                e.g. ./deploy/scripts/devify-deploy.sh manage migrate
@@ -642,10 +702,10 @@ main() {
             compose stop "$@"
             ;;
         restart)
-            check_requirements
-            ensure_env
-            ensure_stack_files
-            compose restart "$@"
+            restart_stack "$@"
+            ;;
+        recreate)
+            recreate_stack "$@"
             ;;
         status)
             status_stack


### PR DESCRIPTION
## Summary

Add deployment commands for safely restarting or force-recreating services in the blue-green production stack.

The existing `restart` command could target the parked `single` API/UI services instead of the color currently serving traffic. This change resolves logical service names against the active blue-green color and adds an explicit `recreate` command.

## Changes

- Add active-color service resolution:
  - `devify-api` → `devify-api-blue` or `devify-api-green`
  - `devify-ui` → `devify-ui-blue` or `devify-ui-green`
- Update `restart` to use the active profile, support logical service names, and acquire the deployment lock.
- Add `recreate` using `docker compose up -d --force-recreate` without pulling images or removing volumes.
- Update deployment help text and documentation.

## Testing

- `bash -n deploy/scripts/devify-deploy.sh`
- `bash scripts/test-install.sh`
- `git diff --check`
- Isolated command-generation tests for blue and green profiles, logical API/UI mapping, explicit service arguments, no-service arguments, and `--force-recreate`

All platform smoke tests passed.

## Deployment impact

- Merging this change does not restart or recreate existing production containers.
- Existing `install`, `upgrade`, and `rollback` flows are unchanged.
- The new `recreate` command is manual and is not invoked by the release workflow.
- No data volumes are removed by the new command.

## Operational notes

Use `upgrade` for normal image releases because it includes image pulling, migrations, health checks, and blue-green traffic switching. Use `restart` for process restarts and `recreate` when the current Compose configuration must be applied to fresh containers. Avoid running `recreate` without service arguments in production unless a full-stack recreation is intentional.